### PR TITLE
[CHORE] stage 환경에 따라가도록 ci-dev를 수정한다

### DIFF
--- a/.github/workflows/ci-dev.yaml
+++ b/.github/workflows/ci-dev.yaml
@@ -26,12 +26,12 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Create application-dev.properties
-        run: echo "${{ secrets.APPLICATION_DEV_PROPERTIES }}" > ./src/main/resources/application-dev.properties
+      - name: Create application-stage.properties
+        run: echo "${{ secrets.APPLICATION_STAGE_PROPERTIES }}" > ./src/main/resources/application-stage.properties
 
       - name: Build with Gradle Wrapper
         env:
-          SPRING_PROFILES_ACTIVE: dev
+          SPRING_PROFILES_ACTIVE: stage
         run: ./gradlew clean build --info --stacktrace --no-daemon
 
       - name: Docker login

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+//	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ repositories {
 }
 
 dependencies {
-//	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.application.name=zighang
+spring.profiles.active=dev


### PR DESCRIPTION
## 기능 설명

stage 서버에 연결된 mysql 설정을 Actions secrets에 APPLICATION_STAGE_PROPERTIES로 설정했습니다.
이후 develop 브랜치에서는 ci가 진행될 때 ci-dev에서 APPLICATION_STAGE_PROPERTIES를 환경변수로 설정했습니다.

그리고 application.properties에서는 spring.profiles.active=dev로 설정하여 개발 환경에서는 application-dev가 실행되도록 설정했습니다.


## 연결된 issue

close #20 

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
