### PR TITLE
[Setting] Swagger 환경 세팅 및 Stage 서버 데이터베이스 세팅

### DIFF
--- a/.github/workflows/ci-dev.yaml
+++ b/.github/workflows/ci-dev.yaml
@@ -30,8 +30,6 @@ jobs:
         run: echo "${{ secrets.APPLICATION_STAGE_PROPERTIES }}" > ./src/main/resources/application-stage.properties
 
       - name: Build with Gradle Wrapper
-        env:
-          SPRING_PROFILES_ACTIVE: stage
         run: ./gradlew clean build --info --stacktrace --no-daemon
 
       - name: Docker login

--- a/.github/workflows/ci-dev.yaml
+++ b/.github/workflows/ci-dev.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Build with Gradle Wrapper
         env:
           SPRING_PROFILES_ACTIVE: stage
-        run: ./gradlew clean build -x test --info --stacktrace --no-daemon
+        run: ./gradlew clean build --info --stacktrace --no-daemon
 
       - name: Docker login
         uses: docker/login-action@v2

--- a/.github/workflows/ci-dev.yaml
+++ b/.github/workflows/ci-dev.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Build with Gradle Wrapper
         env:
           SPRING_PROFILES_ACTIVE: stage
-        run: ./gradlew clean build --info --stacktrace --no-daemon
+        run: ./gradlew clean build -x test --info --stacktrace --no-daemon
 
       - name: Docker login
         uses: docker/login-action@v2

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testImplementation 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -24,10 +24,10 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+//	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ repositories {
 }
 
 dependencies {
-//	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+//	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 //	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 //	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/project/zighang/config/SwaggerConfig.java
+++ b/src/main/java/com/project/zighang/config/SwaggerConfig.java
@@ -9,7 +9,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.util.Arrays;
+import java.util.List;
 
 @Configuration
 public class SwaggerConfig {
@@ -37,6 +37,6 @@ public class SwaggerConfig {
         return new OpenAPI()
                 .components(new Components())
                 .info(info)
-                .servers(Arrays.asList(localServer, stgServer, prdServer));
+                .servers(List.of(localServer, stgServer, prdServer));
     }
 }

--- a/src/main/java/com/project/zighang/config/SwaggerConfig.java
+++ b/src/main/java/com/project/zighang/config/SwaggerConfig.java
@@ -1,0 +1,42 @@
+package com.project.zighang.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Arrays;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Value("${swagger.local.server.url}")
+    private String localServerUrl;
+
+    @Value("${swagger.staging.server.url}")
+    private String stagingServerUrl;
+
+    @Value("${swagger.production.server.url}")
+    private String productionServerUrl;
+
+    @Bean
+    public OpenAPI openAPI() {
+        Info info = new Info()
+                .title("Zighang API Document")
+                .version("v1.0.0")
+                .description("직행 프로젝트의 API 명세서입니다.");
+
+        Server localServer = new Server().url(localServerUrl).description("Local server");
+        Server stgServer = new Server().url(stagingServerUrl).description("Staging server");
+        Server prdServer = new Server().url(productionServerUrl).description("Production server");
+
+        return new OpenAPI()
+                .components(new Components())
+                .info(info)
+                .servers(Arrays.asList(localServer, stgServer, prdServer));
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 spring.application.name=zighang
+
+spring.profiles.active=dev

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,6 @@
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+spring.jpa.hibernate.ddl-auto=create-drop

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -4,3 +4,7 @@ spring.datasource.username=sa
 spring.datasource.password=
 
 spring.jpa.hibernate.ddl-auto=create-drop
+
+swagger.local.server.url=http://test.com
+swagger.staging.server.url=http://test.com
+swagger.production.server.url=http://test.com


### PR DESCRIPTION
## 기능 설명
 1. Swagger 환경 세팅 #16 
<img width="1674" height="527" alt="스크린샷 2025-08-18 오후 10 53 59" src="https://github.com/user-attachments/assets/a8eabfaa-5b0f-437b-915d-fdaae8c2e510" />

- config 패키지를 생성하고 SwaggerConfig 클래스 만들어 스웨거 세팅했습니다.
- 스웨거에 로컬, prod 서버, stage 서버 IP 모두 설정 해두었습니다.

2. Stage 서버 데이터베이스 연결 #23 
- Stage 서버에 해당하는 데이터베이스를 연결합니다.
- Github Actions의 test 단계에서 쿠버네티스의 디비에 직접 접근하지 못하여 test 단계는 h2를 사용하도록 했습니다.
- src/test/resources/application.properties를 만들어 테스트 단계에서 h2를 사용하도록 했습니다.

## 연결된 issue

close #16 
<br>


## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
