### PR TITLE
[FEAT] : 전역 에러 및 API 응답 구현한다

### DIFF
--- a/src/main/java/com/project/zighang/global/config/SwaggerConfig.java
+++ b/src/main/java/com/project/zighang/global/config/SwaggerConfig.java
@@ -1,4 +1,4 @@
-package com.project.zighang.config;
+package com.project.zighang.global.config;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;

--- a/src/main/java/com/project/zighang/global/exception/ApiResponseCode.java
+++ b/src/main/java/com/project/zighang/global/exception/ApiResponseCode.java
@@ -1,0 +1,12 @@
+package com.project.zighang.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ApiResponseCode {
+    HttpStatus getHttpStatus();
+    String getMessage();
+
+    default int getHttpStatusCode() {
+        return getHttpStatus().value();
+    }
+}

--- a/src/main/java/com/project/zighang/global/exception/ControllerExceptionAdvice.java
+++ b/src/main/java/com/project/zighang/global/exception/ControllerExceptionAdvice.java
@@ -1,0 +1,16 @@
+package com.project.zighang.global.exception;
+
+import com.project.zighang.global.template.RspTemplate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+
+public class ControllerExceptionAdvice {
+
+    @ExceptionHandler(CustomException.class)
+    protected ResponseEntity<RspTemplate> handleCustomException(CustomException e , WebRequest request) {
+        return ResponseEntity.status(e.getHttpStatus())
+                .body(RspTemplate.error(e.getError(), e.getMessage()));
+    }
+
+}

--- a/src/main/java/com/project/zighang/global/exception/CustomException.java
+++ b/src/main/java/com/project/zighang/global/exception/CustomException.java
@@ -1,0 +1,18 @@
+package com.project.zighang.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final Error error;
+
+    public CustomException(Error error, String message) {
+        super(message);
+        this.error = error;
+    }
+
+    public int getHttpStatus() {
+        return error.getHttpStatusCode();
+    }
+}

--- a/src/main/java/com/project/zighang/global/exception/Error.java
+++ b/src/main/java/com/project/zighang/global/exception/Error.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public enum Error {
+public enum Error implements ApiResponseCode {
 
     /**
      * 400 BAD REQUEST EXCEPTION
@@ -21,8 +21,4 @@ public enum Error {
 
     private final HttpStatus httpStatus;
     private final String message;
-
-    public int getErrorCode() {
-        return httpStatus.value();
-    }
 }

--- a/src/main/java/com/project/zighang/global/exception/Error.java
+++ b/src/main/java/com/project/zighang/global/exception/Error.java
@@ -1,0 +1,28 @@
+package com.project.zighang.global.exception;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum Error {
+
+    /**
+     * 400 BAD REQUEST EXCEPTION
+     */
+    BAD_CLIENT_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 API 요청입니다."),
+
+    /**
+     * 404 NOT FOUND
+     */
+    NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 정보 입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    public int getErrorCode() {
+        return httpStatus.value();
+    }
+}

--- a/src/main/java/com/project/zighang/global/exception/Success.java
+++ b/src/main/java/com/project/zighang/global/exception/Success.java
@@ -3,8 +3,17 @@ package com.project.zighang.global.exception;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public enum Success {
+public enum Success implements ApiResponseCode {
+
+    /**
+     * 200 OK
+     */
+    GET_API_REQUEST_SUCCESS(HttpStatus.OK, "Get API 호출에 성공했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
 }

--- a/src/main/java/com/project/zighang/global/exception/Success.java
+++ b/src/main/java/com/project/zighang/global/exception/Success.java
@@ -1,0 +1,10 @@
+package com.project.zighang.global.exception;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum Success {
+}

--- a/src/main/java/com/project/zighang/global/exception/model/BadRequestException.java
+++ b/src/main/java/com/project/zighang/global/exception/model/BadRequestException.java
@@ -1,0 +1,10 @@
+package com.project.zighang.global.exception.model;
+
+import com.project.zighang.global.exception.CustomException;
+import com.project.zighang.global.exception.Error;
+
+public class BadRequestException extends CustomException {
+  public BadRequestException(Error error, String message) {
+    super(error, message);
+  }
+}

--- a/src/main/java/com/project/zighang/global/exception/model/NotFoundException.java
+++ b/src/main/java/com/project/zighang/global/exception/model/NotFoundException.java
@@ -1,0 +1,11 @@
+package com.project.zighang.global.exception.model;
+
+import com.project.zighang.global.exception.CustomException;
+import com.project.zighang.global.exception.Error;
+
+public class NotFoundException extends CustomException {
+  public NotFoundException(Error error, String message) {
+    super(error, message);
+  }
+}
+

--- a/src/main/java/com/project/zighang/global/template/RspTemplate.java
+++ b/src/main/java/com/project/zighang/global/template/RspTemplate.java
@@ -1,0 +1,39 @@
+package com.project.zighang.global.template;
+
+import com.project.zighang.global.exception.ApiResponseCode;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class RspTemplate<T> {
+
+    private final int statusCode;
+    private final String message;
+    private final T data;
+
+    // --- 성공 응답 ---
+
+    // 데이터가 없는 성공 응답 (e.g., 삭제 성공)
+    public static RspTemplate<Void> success(ApiResponseCode code) {
+        return new RspTemplate<>(code.getHttpStatusCode(), code.getMessage(), null);
+    }
+
+    // 데이터가 있는 성공 응답
+    public static <T> RspTemplate<T> success(ApiResponseCode code, T data) {
+        return new RspTemplate<>(code.getHttpStatusCode(), code.getMessage(), data);
+    }
+
+    // --- 에러 응답 ---
+
+    // 정적 에러 메시지를 사용하는 에러 응답
+    public static RspTemplate<Void> error(ApiResponseCode code) {
+        return new RspTemplate<>(code.getHttpStatusCode(), code.getMessage(), null);
+    }
+
+    // 동적인 에러 메시지를 사용하는 에러 응답 (e.g., Validation 에러)
+    public static RspTemplate<Void> error(ApiResponseCode code, String message) {
+        return new RspTemplate<>(code.getHttpStatusCode(), message, null);
+    }
+}


### PR DESCRIPTION
## 기능 설명

### 1. API 응답 형식 표준화 (RspTemplate)
모든 API 응답을 일관된 형식으로 제공하기 위해 RspTemplate 클래스를 구현했습니다.
성공과 실패 응답 모두 statusCode, message, data 필드를 포함하는 표준 구조를 따르게 됩니다.
```
// 성공 (데이터 포함)
RspTemplate.success(Success.GET_API_REQUEST_SUCCESS, responseData);

// 성공 (데이터 미포함)
RspTemplate.success(Success.CREATE_SUCCESS);

// 실패
RspTemplate.error(Error.NOT_FOUND);
```

### 2. 전역 예외 처리 (ControllerExceptionAdvice)
@RestControllerAdvice를 사용하여 컨트롤러 계층에서 발생하는 예외를 전역적으로 처리하는 ControllerExceptionAdvice를 구현했습니다.

### 3. API 응답 상태 코드 관리 (ApiResponseCode, Success, Error)
응답 상태(성공/실패)를 관리하기 위해 ApiResponseCode 인터페이스와 이를 구현하는 Success, Error 열거형을 구현했습니다.
새로운 성공 또는 에러 상황이 발생하면, 해당 열거형에 새로운 상수를 추가하면 됩니다.

### 4. 사용자 정의 예외 클래스 (CustomException)
NotFoundException, BadRequestException 등 특정 상황에 맞는 예외 클래스를 CustomException을 상속하여 구현합니다.

## 연결된 issue

close #24 

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
