### PR TITLE
#42 FEAT: 회사 및 기업 뉴스 엔티티를 작성한다

### DIFF
--- a/src/main/java/com/project/zighang/domain/company/entity/Company.java
+++ b/src/main/java/com/project/zighang/domain/company/entity/Company.java
@@ -1,0 +1,34 @@
+package com.project.zighang.domain.company.entity;
+
+import com.project.zighang.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Table(
+        name = "company",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_company_name", columnNames = "company_name")
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Company extends BaseEntity {
+
+    @Column(nullable = false, length = 255)
+    private String companyName;
+
+    @Column(nullable = false, length = 255)
+    private String companyNameKr;
+
+    @Column(length = 100)
+    private String companyType;
+
+    @Column(length = 100)
+    private String industry;
+
+    @Column(length = 100)
+    private String location;
+}
+

--- a/src/main/java/com/project/zighang/domain/company/entity/CompanyNews.java
+++ b/src/main/java/com/project/zighang/domain/company/entity/CompanyNews.java
@@ -6,15 +6,7 @@ import lombok.*;
 import java.time.LocalDate;
 
 @Entity
-@Table(
-        name = "company_news",
-        indexes = {
-                @Index(name = "idx_company_news_company_id", columnList = "company_id")
-        },
-        uniqueConstraints = {
-                @UniqueConstraint(name = "uk_company_news_urlhash", columnNames = "url_hash")
-        }
-)
+@Table(name = "company_news")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/src/main/java/com/project/zighang/domain/company/entity/CompanyNews.java
+++ b/src/main/java/com/project/zighang/domain/company/entity/CompanyNews.java
@@ -1,0 +1,37 @@
+package com.project.zighang.domain.company.entity;
+
+import com.project.zighang.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDate;
+
+@Entity
+@Table(
+        name = "company_news",
+        indexes = {
+                @Index(name = "idx_company_news_company_id", columnList = "company_id")
+        },
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_company_news_urlhash", columnNames = "url_hash")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CompanyNews extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "company_id", foreignKey = @ForeignKey(name = "fk_company_news_company"))
+    private Company company;
+
+    @Column(nullable = false, columnDefinition = "varchar(1000)")
+    private String title;
+
+    @Column(columnDefinition = "varchar(2048)")
+    private String url;
+
+    private LocalDate publishedAt;
+
+    @Column(columnDefinition = "varchar(2048)")
+    private String thumbnailUrl;
+}


### PR DESCRIPTION
## 기능 설명

- Company Entity 및 관련 기능 구현
- CompanyNews Entity 및 관련 기능 구현

<img width="394" height="315" alt="image" src="https://github.com/user-attachments/assets/30c972ae-f871-4dc3-ba99-6e852fd58eee" />
<img width="551" height="320" alt="image" src="https://github.com/user-attachments/assets/5c01d9a1-ba2a-4dc1-89d1-7c52983aa120" />

<br>

## 연결된 issue

close #42

<br>

## Approve 하기 전 확인해주세요!

- [ ] Company Entity 필드 설계가 요구사항에 맞는지 확인

<br>

## ✅ 체크리스트

- [ x] PR 제목 규칙 잘 지켰는가?
- [ x] 추가/수정사항을 설명하였는가?
- [ x] 테스트 결과 사진을 넣었는가?
- [ x] 이슈넘버를 적었는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 회사 정보 관리와 회사별 뉴스 항목을 추가했습니다. 회사명 중복 방지가 적용되며 뉴스 항목을 회사와 연계해 조회할 수 있습니다.
- **Chores**
  - 데이터 무결성 강화를 위한 고유성 제약이 도입되어 중복 입력을 방지합니다. 사용자 인터페이스 변경은 없습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->