### PR TITLE
[Fix] Onboarding API 수정하다

### DIFF
--- a/src/main/java/com/project/zighang/user/dto/PostUserOnboardingDto.java
+++ b/src/main/java/com/project/zighang/user/dto/PostUserOnboardingDto.java
@@ -9,8 +9,11 @@ public record PostUserOnboardingDto(
         @Schema(description = "사용자 ID (토큰 구현 전까지 임시 사용)", example = "1")
         Long userId,
 
-        @Schema(description = "경력 연차 (신입: 0, 1년차: 1, 2년차: 2...)", example = "3") @Min(0)
-        Long career,
+        @Schema(description = "최소 경력 연차 (신입: 0, 1년차: 1, 2년차: 2...)", example = "3") @Min(0)
+        Long minCareer,
+
+        @Schema(description = "최대 경력 연차 (신입: 0, 1년차: 1, 2년차: 2...)", example = "3") @Min(0)
+        Long maxCareer,
 
         @Schema(description = "관심 지역 목록")
         List<AddressDto> addressList,

--- a/src/main/java/com/project/zighang/user/entity/UserOnboardingEntity.java
+++ b/src/main/java/com/project/zighang/user/entity/UserOnboardingEntity.java
@@ -17,20 +17,24 @@ public class UserOnboardingEntity extends BaseEntity {
     private UserEntity userEntity;
 
     // 신입 -1, 경력은 +1 +2 .. 로 받을 예정
-    private Long career;
+    private Long minCareer;
+
+    private Long maxCareer;
 
     private Long dailyRecommendPostCount;
 
-    public static UserOnboardingEntity create(UserEntity userEntity, Long career) {
+    public static UserOnboardingEntity create(UserEntity userEntity, Long minCareer, Long maxCareer) {
         return UserOnboardingEntity.builder()
                 .userEntity(userEntity)
-                .career(career)
+                .minCareer(minCareer)
+                .maxCareer(maxCareer)
                 .dailyRecommendPostCount(0L)
                 .build();
     }
 
-    public void updateUserCareer(Long career) {
-        this.career = career;
+    public void updateUserCareer(Long minCareer, Long maxCareer) {
+        this.minCareer = minCareer;
+        this.maxCareer = maxCareer;
     }
 
     public void updateDailyRecommendPostCount(Long dailyRecommendPostCount){

--- a/src/main/java/com/project/zighang/user/entity/UserOnboardingEntity.java
+++ b/src/main/java/com/project/zighang/user/entity/UserOnboardingEntity.java
@@ -21,6 +21,8 @@ public class UserOnboardingEntity extends BaseEntity {
 
     private Long maxCareer;
 
+    private Long careerYears;
+
     private Long dailyRecommendPostCount;
 
     public static UserOnboardingEntity create(UserEntity userEntity, Long minCareer, Long maxCareer) {
@@ -28,6 +30,7 @@ public class UserOnboardingEntity extends BaseEntity {
                 .userEntity(userEntity)
                 .minCareer(minCareer)
                 .maxCareer(maxCareer)
+                .careerYears(Math.max(0, maxCareer - minCareer))
                 .dailyRecommendPostCount(0L)
                 .build();
     }
@@ -35,9 +38,14 @@ public class UserOnboardingEntity extends BaseEntity {
     public void updateUserCareer(Long minCareer, Long maxCareer) {
         this.minCareer = minCareer;
         this.maxCareer = maxCareer;
+        updateCareerYears();
     }
 
     public void updateDailyRecommendPostCount(Long dailyRecommendPostCount){
         this.dailyRecommendPostCount = dailyRecommendPostCount;
+    }
+
+    private void updateCareerYears() {
+        careerYears = Math.max(0, maxCareer - minCareer);
     }
 }

--- a/src/main/java/com/project/zighang/user/service/UserServiceImpl.java
+++ b/src/main/java/com/project/zighang/user/service/UserServiceImpl.java
@@ -46,6 +46,9 @@ public class UserServiceImpl implements UserService {
         if (minCareer == null || minCareer < 0 || maxCareer == null || maxCareer < 0) {
             throw new BadRequestException(Error.BAD_REQUEST_CAREER_VALUE, Error.BAD_REQUEST_CAREER_VALUE.getMessage());
         }
+        if (minCareer > maxCareer) {
+            throw new BadRequestException(Error.BAD_REQUEST_CAREER_VALUE, "minCareer는 maxCareer보다 클 수 없습니다.");
+        }
 
         // Onboarding Entity
         userOnboardingRepository.findByUserEntity(userEntity)

--- a/src/main/java/com/project/zighang/user/service/UserServiceImpl.java
+++ b/src/main/java/com/project/zighang/user/service/UserServiceImpl.java
@@ -41,8 +41,9 @@ public class UserServiceImpl implements UserService {
                 () -> new NotFoundException(Error.NOT_FOUND_USER, Error.NOT_FOUND_USER.getMessage())
         );
 
-        Long career = request.career();
-        if (career == null || career < 0) {
+        Long minCareer = request.minCareer();
+        Long maxCareer = request.maxCareer();
+        if (minCareer == null || minCareer < 0 || maxCareer == null || maxCareer < 0) {
             throw new BadRequestException(Error.BAD_REQUEST_CAREER_VALUE, Error.BAD_REQUEST_CAREER_VALUE.getMessage());
         }
 
@@ -50,14 +51,11 @@ public class UserServiceImpl implements UserService {
         userOnboardingRepository.findByUserEntity(userEntity)
                 .ifPresentOrElse(
                         onboardingEntity -> {
-                            log.info("온보딩 정보가 존재하여 새로운 정보로 수정합니다. userId: {}", userId);
-                            if (!Objects.equals(onboardingEntity.getCareer(), request.career())) {
-                                onboardingEntity.updateUserCareer(request.career());
-                            }
+                            log.error("이미 온보딩 정보가 존재합니다. userId: {}", userId);
                         }, () -> {
                             log.info("온보딩 정보가 없어 새로 저장합니다. userId: {}", userId);
                             UserOnboardingEntity userOnboardingEntity = UserOnboardingEntity.create(
-                                    userEntity, request.career());
+                                    userEntity, request.minCareer(), request.maxCareer());
                             userOnboardingRepository.save(userOnboardingEntity);
                             log.info("새로운 온보딩 정보를 저장했습니다.");
                         }


### PR DESCRIPTION
## 기능 설명
- Onboarding API Request DTO 및 Entity 수정했습니다. 온보딩 과정에서 경력의 범위를 설정하는 요구사항으로 인해 minCareer와 maxCareer로 사용자의 경력 범위를 저장하도록 수정했습니다.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="249" height="376" alt="스크린샷 2025-09-02 오후 6 51 05" src="https://github.com/user-attachments/assets/60459294-a792-4796-9c20-13cd02c75ae6" />


## 연결된 issue

close #48 

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 온보딩에서 경력을 단일 값 대신 최소/최대 범위로 입력할 수 있어 보다 세밀한 경력 설정이 가능합니다.
- 버그 수정
  - 음수 등 유효하지 않은 경력 입력을 차단하고, 최소값이 최대값보다 큰 경우 제출을 막아 안정성을 높였습니다.
  - 이미 온보딩이 등록된 경우 중복 생성/덮어쓰기가 발생하지 않도록 처리했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->