### PR TITLE
[Feat] 오늘의 지원 기능 CRUD API 구현하다

### DIFF
--- a/src/main/java/com/project/zighang/global/exception/Error.java
+++ b/src/main/java/com/project/zighang/global/exception/Error.java
@@ -15,12 +15,14 @@ public enum Error implements ApiResponseCode {
     BAD_CLIENT_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 API 요청입니다."),
     BAD_REQUEST_APPLY_COUNT_VALUE(HttpStatus.BAD_REQUEST, "오늘의 공고 개수는 0개 이상이어야 합니다."),
     BAD_REQUEST_CAREER_VALUE(HttpStatus.BAD_REQUEST, "잘못된 커리어 데이터입니다."),
+    BAD_REQUEST_ALREADY_APPLIED(HttpStatus.BAD_REQUEST, "이미 지원한 공고입니다."),
 
     /**
      * 404 NOT FOUND
      */
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, "존재하지 않는 사용자 정보입니다."),
     NOT_FOUND_USER_ONBOARDING(HttpStatus.NOT_FOUND, "존재하지 않는 사용자 온보딩 정보입니다."),
+    NOT_FOUND_POST(HttpStatus.NOT_FOUND, "존재하지 않는 공고입니다."),
 
     /**
      * Redis Error

--- a/src/main/java/com/project/zighang/global/exception/Error.java
+++ b/src/main/java/com/project/zighang/global/exception/Error.java
@@ -13,6 +13,7 @@ public enum Error implements ApiResponseCode {
      * 400 BAD REQUEST EXCEPTION
      */
     BAD_CLIENT_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 API 요청입니다."),
+    BAD_REQUEST_APPLY_COUNT_VALUE(HttpStatus.BAD_REQUEST, "오늘의 공고 개수는 0개 이상이어야 합니다."),
     BAD_REQUEST_CAREER_VALUE(HttpStatus.BAD_REQUEST, "잘못된 커리어 데이터입니다."),
 
     /**

--- a/src/main/java/com/project/zighang/global/exception/Error.java
+++ b/src/main/java/com/project/zighang/global/exception/Error.java
@@ -19,6 +19,7 @@ public enum Error implements ApiResponseCode {
      * 404 NOT FOUND
      */
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, "존재하지 않는 사용자 정보입니다."),
+    NOT_FOUND_USER_ONBOARDING(HttpStatus.NOT_FOUND, "존재하지 않는 사용자 온보딩 정보입니다."),
 
     /**
      * Redis Error

--- a/src/main/java/com/project/zighang/global/exception/Success.java
+++ b/src/main/java/com/project/zighang/global/exception/Success.java
@@ -22,9 +22,9 @@ public enum Success implements ApiResponseCode {
     POST_USER_Onboarding_API_REQUEST_SUCCESS(HttpStatus.CREATED, "유저 온보딩 POST API 호출에 성공했습니다."),
     CREATE_JWT_TOKEN_SUCCESS(HttpStatus.CREATED, "소셜 로그인 성공 및 JWT 토큰 정상 발급했습니다."),
     SUBSCRIBE_SUCCESS(HttpStatus.CREATED, "정상적으로 구독됐습니다."),
+    POST_JOB_APPLY(HttpStatus.CREATED, "정상적으로 공고에 지원했습니다."),
 
     POST_USER_APPLY_COUNT_API_REQUEST_SUCCESS(HttpStatus.OK, "유저 하루 추천 공고 개수가 설정되었습니다.");
-
 
 
 

--- a/src/main/java/com/project/zighang/global/exception/Success.java
+++ b/src/main/java/com/project/zighang/global/exception/Success.java
@@ -21,7 +21,9 @@ public enum Success implements ApiResponseCode {
      */
     POST_USER_Onboarding_API_REQUEST_SUCCESS(HttpStatus.CREATED, "유저 온보딩 POST API 호출에 성공했습니다."),
     CREATE_JWT_TOKEN_SUCCESS(HttpStatus.CREATED, "소셜 로그인 성공 및 JWT 토큰 정상 발급했습니다."),
-    SUBSCRIBE_SUCCESS(HttpStatus.CREATED, "정상적으로 구독됐습니다.");
+    SUBSCRIBE_SUCCESS(HttpStatus.CREATED, "정상적으로 구독됐습니다."),
+
+    POST_USER_APPLY_COUNT_API_REQUEST_SUCCESS(HttpStatus.OK, "유저 하루 추천 공고 개수가 설정되었습니다.");
 
 
 

--- a/src/main/java/com/project/zighang/post/controller/PostController.java
+++ b/src/main/java/com/project/zighang/post/controller/PostController.java
@@ -5,7 +5,7 @@ import com.project.zighang.global.template.RspTemplate;
 import com.project.zighang.post.dto.PageDto;
 import com.project.zighang.post.dto.PostApplyJobDto;
 import com.project.zighang.post.dto.PostResponseDto;
-import com.project.zighang.post.service.PostServiceImpl;
+import com.project.zighang.post.service.PostService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -20,7 +20,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class PostController {
 
-    private final PostServiceImpl postService;
+    private final PostService postService;
 
     @GetMapping
     @Operation(summary = "공고 전체 목록 조회", description = "채용공고 목록을 페이지네이션하여 조회합니다. score 기반 내림차순 정렬입니다.")

--- a/src/main/java/com/project/zighang/post/controller/PostController.java
+++ b/src/main/java/com/project/zighang/post/controller/PostController.java
@@ -2,8 +2,8 @@ package com.project.zighang.post.controller;
 
 import com.project.zighang.global.exception.Success;
 import com.project.zighang.global.template.RspTemplate;
-import com.project.zighang.post.dto.GetTodayApplyPostDto;
 import com.project.zighang.post.dto.PageDto;
+import com.project.zighang.post.dto.PostApplyJobDto;
 import com.project.zighang.post.dto.PostResponseDto;
 import com.project.zighang.post.service.PostServiceImpl;
 import io.swagger.v3.oas.annotations.Operation;
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/job-post")
+@RequestMapping("/api/post")
 @RequiredArgsConstructor
 public class PostController {
 
@@ -45,5 +45,14 @@ public class PostController {
     ) {
         List<PostResponseDto> todayApplyPosts = postService.getTodayApplyPostList(userId);
         return RspTemplate.success(Success.GET_API_REQUEST_SUCCESS, todayApplyPosts);
+    }
+
+    @PostMapping("/apply")
+    @Operation(summary = "공고 지원", description = "이미 지원한 공고는 다시 지원할 수 없습니다.")
+    public RspTemplate<?> applyInJobPost(
+            @RequestBody PostApplyJobDto request
+    ) {
+        postService.applyJobPost(request);
+        return RspTemplate.success(Success.POST_JOB_APPLY);
     }
 }

--- a/src/main/java/com/project/zighang/post/controller/PostController.java
+++ b/src/main/java/com/project/zighang/post/controller/PostController.java
@@ -2,6 +2,7 @@ package com.project.zighang.post.controller;
 
 import com.project.zighang.global.exception.Success;
 import com.project.zighang.global.template.RspTemplate;
+import com.project.zighang.post.dto.GetTodayApplyPostDto;
 import com.project.zighang.post.dto.PageDto;
 import com.project.zighang.post.dto.PostResponseDto;
 import com.project.zighang.post.service.PostServiceImpl;
@@ -10,10 +11,9 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/job-post")
@@ -36,5 +36,14 @@ public class PostController {
         int safeSize = Math.max(size, 1);
         Page<PostResponseDto> postPage = postService.getAllPostList(pageInIndex, safeSize);
         return RspTemplate.success(Success.GET_API_REQUEST_SUCCESS, PageDto.from(postPage));
+    }
+
+    @GetMapping("/today-apply")
+    @Operation(summary = "오늘의 추천 공고 목록 조회")
+    public RspTemplate<?> getTodayApplyPosts(
+            @RequestParam Long userId
+    ) {
+        List<PostResponseDto> todayApplyPosts = postService.getTodayApplyPostList(userId);
+        return RspTemplate.success(Success.GET_API_REQUEST_SUCCESS, todayApplyPosts);
     }
 }

--- a/src/main/java/com/project/zighang/post/dto/GetTodayApplyPostDto.java
+++ b/src/main/java/com/project/zighang/post/dto/GetTodayApplyPostDto.java
@@ -1,6 +1,0 @@
-package com.project.zighang.post.dto;
-
-public record GetTodayApplyPostDto(
-        Long userId
-) {
-}

--- a/src/main/java/com/project/zighang/post/dto/GetTodayApplyPostDto.java
+++ b/src/main/java/com/project/zighang/post/dto/GetTodayApplyPostDto.java
@@ -1,0 +1,6 @@
+package com.project.zighang.post.dto;
+
+public record GetTodayApplyPostDto(
+        Long userId
+) {
+}

--- a/src/main/java/com/project/zighang/post/dto/PostApplyJobDto.java
+++ b/src/main/java/com/project/zighang/post/dto/PostApplyJobDto.java
@@ -1,0 +1,6 @@
+package com.project.zighang.post.dto;
+
+public record PostApplyJobDto(
+        Long userId, Long recruitmentId
+) {
+}

--- a/src/main/java/com/project/zighang/post/entity/PostApplyEntity.java
+++ b/src/main/java/com/project/zighang/post/entity/PostApplyEntity.java
@@ -1,0 +1,35 @@
+package com.project.zighang.post.entity;
+
+import com.project.zighang.global.common.BaseEntity;
+import com.project.zighang.user.entity.UserEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Builder
+@Entity
+@Table(name = "post_apply_entity", uniqueConstraints = {
+        @UniqueConstraint(
+                name = "post_apply_uk",
+                columnNames = {"user_entity_id", "recruitment_id"}
+        )
+})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class PostApplyEntity extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_entity_id")
+    private UserEntity userEntity;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recruitment_id")
+    private PostEntity postEntity;
+
+    public static PostApplyEntity create(UserEntity userEntity, PostEntity postEntity) {
+        return PostApplyEntity.builder()
+                .userEntity(userEntity)
+                .postEntity(postEntity)
+                .build();
+    }
+}

--- a/src/main/java/com/project/zighang/post/repository/PostApplyEntityRepository.java
+++ b/src/main/java/com/project/zighang/post/repository/PostApplyEntityRepository.java
@@ -1,0 +1,12 @@
+package com.project.zighang.post.repository;
+
+import com.project.zighang.post.entity.PostApplyEntity;
+import com.project.zighang.post.entity.PostEntity;
+import com.project.zighang.user.entity.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostApplyEntityRepository extends JpaRepository<PostApplyEntity, Long> {
+    boolean existsByUserEntityAndPostEntity(UserEntity userEntity, PostEntity postEntity);
+}

--- a/src/main/java/com/project/zighang/post/service/PostService.java
+++ b/src/main/java/com/project/zighang/post/service/PostService.java
@@ -1,8 +1,12 @@
 package com.project.zighang.post.service;
 
+import com.project.zighang.post.dto.GetTodayApplyPostDto;
 import com.project.zighang.post.dto.PostResponseDto;
 import org.springframework.data.domain.Page;
 
+import java.util.List;
+
 public interface PostService {
     Page<PostResponseDto> getAllPostList(int page, int size);
+    List<PostResponseDto> getTodayApplyPostList(Long userId);
 }

--- a/src/main/java/com/project/zighang/post/service/PostService.java
+++ b/src/main/java/com/project/zighang/post/service/PostService.java
@@ -1,6 +1,6 @@
 package com.project.zighang.post.service;
 
-import com.project.zighang.post.dto.GetTodayApplyPostDto;
+import com.project.zighang.post.dto.PostApplyJobDto;
 import com.project.zighang.post.dto.PostResponseDto;
 import org.springframework.data.domain.Page;
 
@@ -9,4 +9,6 @@ import java.util.List;
 public interface PostService {
     Page<PostResponseDto> getAllPostList(int page, int size);
     List<PostResponseDto> getTodayApplyPostList(Long userId);
+
+    void applyJobPost(PostApplyJobDto request);
 }

--- a/src/main/java/com/project/zighang/post/service/PostServiceImpl.java
+++ b/src/main/java/com/project/zighang/post/service/PostServiceImpl.java
@@ -1,8 +1,14 @@
 package com.project.zighang.post.service;
 
+import com.project.zighang.global.exception.Error;
+import com.project.zighang.global.exception.model.NotFoundException;
 import com.project.zighang.post.repository.PostEntityRepository;
 import com.project.zighang.post.dto.PostResponseDto;
 import com.project.zighang.post.entity.PostEntity;
+import com.project.zighang.user.entity.UserEntity;
+import com.project.zighang.user.entity.UserOnboardingEntity;
+import com.project.zighang.user.repository.UserOnboardingRepository;
+import com.project.zighang.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -18,6 +24,8 @@ import java.util.List;
 public class PostServiceImpl implements PostService {
 
     private final PostEntityRepository postEntityRepository;
+    private final UserOnboardingRepository userOnboardingRepository;
+    private final UserRepository userRepository;
 
     private static final int MAX_SIZE = 50;
 
@@ -33,5 +41,32 @@ public class PostServiceImpl implements PostService {
     private Page<PostEntity> getAllPostListByRepository(int page, int size) {
         Pageable pageable = PageRequest.of(page, size, Sort.by("viewCount").descending());
         return postEntityRepository.findAll(pageable);
+    }
+
+    @Override
+    public List<PostResponseDto> getTodayApplyPostList(Long userId) {
+        UserEntity userEntity = userRepository.findById(userId).orElseThrow(
+                () -> new NotFoundException(
+                        com.project.zighang.global.exception.Error.NOT_FOUND_USER, com.project.zighang.global.exception.Error.NOT_FOUND_USER.getMessage())
+        );
+        UserOnboardingEntity userOnboardingEntity = userOnboardingRepository.findByUserEntity(userEntity).orElseThrow(
+                () -> new NotFoundException(
+                        com.project.zighang.global.exception.Error.NOT_FOUND_USER_ONBOARDING, Error.NOT_FOUND_USER_ONBOARDING.getMessage())
+        );
+
+        Long applyPostCount = userOnboardingEntity.getDailyRecommendPostCount();
+        if (applyPostCount != null && applyPostCount >= 0) {
+            return getAllPostListByRepository(Math.toIntExact(applyPostCount))
+                    .stream()
+                    .map(PostResponseDto::from)
+                    .toList();
+        }
+
+        return List.of();
+    }
+
+    private List<PostEntity> getAllPostListByRepository(int applyPostCount) {
+        Pageable pageable = PageRequest.of(0, applyPostCount, Sort.by("viewCount").descending());
+        return postEntityRepository.findAll(pageable).getContent();
     }
 }

--- a/src/main/java/com/project/zighang/post/service/PostServiceImpl.java
+++ b/src/main/java/com/project/zighang/post/service/PostServiceImpl.java
@@ -1,7 +1,11 @@
 package com.project.zighang.post.service;
 
 import com.project.zighang.global.exception.Error;
+import com.project.zighang.global.exception.model.BadRequestException;
 import com.project.zighang.global.exception.model.NotFoundException;
+import com.project.zighang.post.dto.PostApplyJobDto;
+import com.project.zighang.post.entity.PostApplyEntity;
+import com.project.zighang.post.repository.PostApplyEntityRepository;
 import com.project.zighang.post.repository.PostEntityRepository;
 import com.project.zighang.post.dto.PostResponseDto;
 import com.project.zighang.post.entity.PostEntity;
@@ -20,27 +24,24 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class PostServiceImpl implements PostService {
 
     private final PostEntityRepository postEntityRepository;
     private final UserOnboardingRepository userOnboardingRepository;
     private final UserRepository userRepository;
+    private final PostApplyEntityRepository postApplyEntityRepository;
 
     private static final int MAX_SIZE = 50;
 
     @Override
     @Transactional(readOnly = true)
     public Page<PostResponseDto> getAllPostList(int page, int size) {
-        int normalizedSize = Math.min(Math.max(size, 1), MAX_SIZE);
         int normalizedPage = Math.max(page, 0);
-        return getAllPostListByRepository(normalizedPage, normalizedSize)
-                .map(PostResponseDto::from);
-    }
-
-    private Page<PostEntity> getAllPostListByRepository(int page, int size) {
-        Pageable pageable = PageRequest.of(page, size, Sort.by("viewCount").descending());
-        return postEntityRepository.findAll(pageable);
+        int normalizedSize = Math.min(Math.max(size, 1), MAX_SIZE);
+        Pageable pageable = PageRequest.of(normalizedPage, normalizedSize, Sort.by("viewCount").descending());
+        return findPostsByViewCount(pageable).map(PostResponseDto::from);
     }
 
     @Override
@@ -56,7 +57,7 @@ public class PostServiceImpl implements PostService {
 
         Long applyPostCount = userOnboardingEntity.getDailyRecommendPostCount();
         if (applyPostCount != null && applyPostCount >= 0) {
-            return getAllPostListByRepository(Math.toIntExact(applyPostCount))
+            return findTopNPostsByViewCount(Math.toIntExact(applyPostCount))
                     .stream()
                     .map(PostResponseDto::from)
                     .toList();
@@ -65,8 +66,28 @@ public class PostServiceImpl implements PostService {
         return List.of();
     }
 
-    private List<PostEntity> getAllPostListByRepository(int applyPostCount) {
-        Pageable pageable = PageRequest.of(0, applyPostCount, Sort.by("viewCount").descending());
+    @Override
+    public void applyJobPost(PostApplyJobDto request) {
+        UserEntity userEntity = userRepository.findById(request.userId()).orElseThrow(
+                () -> new NotFoundException(Error.NOT_FOUND_USER, Error.NOT_FOUND_USER.getMessage())
+        );
+        PostEntity postEntity = postEntityRepository.findById(request.recruitmentId()).orElseThrow(
+                () -> new NotFoundException(Error.NOT_FOUND_POST, Error.NOT_FOUND_POST.getMessage())
+        );
+
+        if (postApplyEntityRepository.existsByUserEntityAndPostEntity(userEntity, postEntity)) {
+            throw new BadRequestException(Error.BAD_REQUEST_ALREADY_APPLIED, Error.BAD_REQUEST_ALREADY_APPLIED.getMessage());
+        }
+
+        postApplyEntityRepository.save(PostApplyEntity.create(userEntity, postEntity));
+    }
+
+    private Page<PostEntity> findPostsByViewCount(Pageable pageable) {
+        return postEntityRepository.findAll(pageable);
+    }
+
+    private List<PostEntity> findTopNPostsByViewCount(int count) {
+        Pageable pageable = PageRequest.of(0, count, Sort.by("viewCount").descending());
         return postEntityRepository.findAll(pageable).getContent();
     }
 }

--- a/src/main/java/com/project/zighang/post/service/PostServiceImpl.java
+++ b/src/main/java/com/project/zighang/post/service/PostServiceImpl.java
@@ -48,11 +48,11 @@ public class PostServiceImpl implements PostService {
     public List<PostResponseDto> getTodayApplyPostList(Long userId) {
         UserEntity userEntity = userRepository.findById(userId).orElseThrow(
                 () -> new NotFoundException(
-                        com.project.zighang.global.exception.Error.NOT_FOUND_USER, com.project.zighang.global.exception.Error.NOT_FOUND_USER.getMessage())
+                        Error.NOT_FOUND_USER, com.project.zighang.global.exception.Error.NOT_FOUND_USER.getMessage())
         );
         UserOnboardingEntity userOnboardingEntity = userOnboardingRepository.findByUserEntity(userEntity).orElseThrow(
                 () -> new NotFoundException(
-                        com.project.zighang.global.exception.Error.NOT_FOUND_USER_ONBOARDING, Error.NOT_FOUND_USER_ONBOARDING.getMessage())
+                        Error.NOT_FOUND_USER_ONBOARDING, Error.NOT_FOUND_USER_ONBOARDING.getMessage())
         );
 
         Long applyPostCount = userOnboardingEntity.getDailyRecommendPostCount();

--- a/src/main/java/com/project/zighang/user/controller/UserController.java
+++ b/src/main/java/com/project/zighang/user/controller/UserController.java
@@ -3,16 +3,14 @@ package com.project.zighang.user.controller;
 import com.project.zighang.global.exception.Success;
 import com.project.zighang.global.template.RspTemplate;
 import com.project.zighang.user.dto.PostUserOnboardingDto;
+import com.project.zighang.user.dto.PostUserTodayApplyCountDTO;
 import com.project.zighang.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -37,5 +35,16 @@ public class UserController {
     ) {
         userService.addUserOnboardingInfo(postUserOnboardingDto);
         return RspTemplate.success(Success.POST_USER_Onboarding_API_REQUEST_SUCCESS);
+    }
+
+    @PostMapping("/today-apply")
+    @Operation(
+            summary = "사용자 오늘의 지원 개수 정보 저장"
+    )
+    public RspTemplate<?> postUserTodayApplyCount(
+            @RequestBody PostUserTodayApplyCountDTO dto
+    ) {
+        userService.setUserApplyCount(dto);
+        return RspTemplate.success(Success.POST_USER_APPLY_COUNT_API_REQUEST_SUCCESS);
     }
 }

--- a/src/main/java/com/project/zighang/user/dto/PostUserTodayApplyCountDTO.java
+++ b/src/main/java/com/project/zighang/user/dto/PostUserTodayApplyCountDTO.java
@@ -1,0 +1,9 @@
+package com.project.zighang.user.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record PostUserTodayApplyCountDTO(
+        Long userId,
+        @NotNull Long applyCount
+) {
+}

--- a/src/main/java/com/project/zighang/user/entity/UserEntity.java
+++ b/src/main/java/com/project/zighang/user/entity/UserEntity.java
@@ -4,8 +4,6 @@ import com.project.zighang.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.Instant;
-
 @Getter
 @Builder
 @Entity

--- a/src/main/java/com/project/zighang/user/service/UserService.java
+++ b/src/main/java/com/project/zighang/user/service/UserService.java
@@ -1,7 +1,9 @@
 package com.project.zighang.user.service;
 
 import com.project.zighang.user.dto.PostUserOnboardingDto;
+import com.project.zighang.user.dto.PostUserTodayApplyCountDTO;
 
 public interface UserService {
     void addUserOnboardingInfo(PostUserOnboardingDto request);
+    void setUserApplyCount(PostUserTodayApplyCountDTO request);
 }

--- a/src/main/java/com/project/zighang/user/service/UserServiceImpl.java
+++ b/src/main/java/com/project/zighang/user/service/UserServiceImpl.java
@@ -3,6 +3,7 @@ package com.project.zighang.user.service;
 import com.project.zighang.global.exception.model.BadRequestException;
 import com.project.zighang.global.exception.model.NotFoundException;
 import com.project.zighang.user.dto.PostUserOnboardingDto;
+import com.project.zighang.user.dto.PostUserTodayApplyCountDTO;
 import com.project.zighang.user.entity.AddressEntity;
 import com.project.zighang.user.entity.IndustryEntity;
 import com.project.zighang.user.entity.UserEntity;
@@ -18,7 +19,6 @@ import org.springframework.transaction.annotation.Transactional;
 import com.project.zighang.global.exception.Error;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -35,7 +35,6 @@ public class UserServiceImpl implements UserService {
     @Override
     public void addUserOnboardingInfo(PostUserOnboardingDto request) {
         Long userId = request.userId();
-
         // User Entity 유무 확인, User Entity는 소셜 로그인 과정에서 생성되어 디비에 저장됨
         UserEntity userEntity = userRepository.findById(userId).orElseThrow(
                 () -> new NotFoundException(Error.NOT_FOUND_USER, Error.NOT_FOUND_USER.getMessage())
@@ -81,5 +80,22 @@ public class UserServiceImpl implements UserService {
                 .collect(Collectors.toList());
 
         industryRepository.saveAll(newIndustries);
+    }
+
+    @Override
+    public void setUserApplyCount(PostUserTodayApplyCountDTO request) {
+        if (request.applyCount() < 0) {
+            throw  new BadRequestException(Error.BAD_CLIENT_REQUEST, Error.BAD_CLIENT_REQUEST.getMessage());
+        }
+
+        Long userId = request.userId();
+        UserEntity userEntity = userRepository.findById(userId).orElseThrow(
+                () -> new NotFoundException(Error.NOT_FOUND_USER, Error.NOT_FOUND_USER.getMessage())
+        );
+        UserOnboardingEntity userOnboardingEntity = userOnboardingRepository.findByUserEntity(userEntity).orElseThrow(
+                () -> new NotFoundException(Error.NOT_FOUND_USER_ONBOARDING, Error.NOT_FOUND_USER_ONBOARDING.getMessage())
+        );
+
+        userOnboardingEntity.updateDailyRecommendPostCount(request.applyCount());
     }
 }

--- a/src/main/java/com/project/zighang/user/service/UserServiceImpl.java
+++ b/src/main/java/com/project/zighang/user/service/UserServiceImpl.java
@@ -85,7 +85,7 @@ public class UserServiceImpl implements UserService {
     @Override
     public void setUserApplyCount(PostUserTodayApplyCountDTO request) {
         if (request.applyCount() < 0) {
-            throw  new BadRequestException(Error.BAD_CLIENT_REQUEST, Error.BAD_CLIENT_REQUEST.getMessage());
+            throw  new BadRequestException(Error.BAD_REQUEST_APPLY_COUNT_VALUE, Error.BAD_REQUEST_APPLY_COUNT_VALUE.getMessage());
         }
 
         Long userId = request.userId();


### PR DESCRIPTION
## 기능 설명
#### 오늘의 지원 CRUD API 구현
- 오늘의 지원 개수 설정 API
- 오늘의 지원 찾기 API (일단 임의의 공고를 내려주고 추천 시스템 구현 이후 추천 시스템을 따름)
- 오늘의 공고 리스트 조회 API
- 공고 지원 API 구현

swagger 테스트 성공 결과 스크린샷 첨부
<img width="690" height="519" alt="스크린샷 2025-09-04 오전 1 36 43" src="https://github.com/user-attachments/assets/401b7401-3952-4a6a-9342-b4d025dbbd35" />

## 연결된 issue

close #47 

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
