### PR TITLE
[Feat] kakao social redirect url 추가 및 @AuthenticationPrincipal 활용

### DIFF
--- a/src/main/java/com/project/zighang/oauth2/controller/KakaoLoginController.java
+++ b/src/main/java/com/project/zighang/oauth2/controller/KakaoLoginController.java
@@ -25,8 +25,9 @@ public class KakaoLoginController {
     @Operation(
             summary = "카카오 소셜 로그인",
             description = """
-    카카오 인가 코드로 소셜 로그인을 진행하며, 성공 시 서비스 자체 JWT(Access/Refresh Token)와 신규 가입 여부를 반환합니다.
-    처음 로그인한 유저의 경우 isNewUser가 참으로 내려갑니다.
+    카카오 인가 코드로 소셜 로그인을 진행합니다.
+    성공 시, 서비스 자체 JWT(Access/Refresh Token)는 응답의 HttpOnly 쿠키에 설정됩니다.
+    이후, isNewUser 값을 쿼리 파라미터로 포함하여 프론트엔드의 콜백 URL로 리다이렉트합니다.
     """
     )
     public void kakaoLoginAndRedirect(

--- a/src/main/java/com/project/zighang/oauth2/controller/KakaoLoginController.java
+++ b/src/main/java/com/project/zighang/oauth2/controller/KakaoLoginController.java
@@ -1,16 +1,18 @@
 package com.project.zighang.oauth2.controller;
 
-import com.project.zighang.global.exception.Success;
-import com.project.zighang.global.template.RspTemplate;
 import com.project.zighang.oauth2.dto.TokenResult;
 import com.project.zighang.oauth2.service.KakaoLoginService;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
 
 @RestController
 @RequestMapping("/v1/auth/kakao")
@@ -27,10 +29,28 @@ public class KakaoLoginController {
     처음 로그인한 유저의 경우 isNewUser가 참으로 내려갑니다.
     """
     )
-    public RspTemplate<?> kakaoLogin(
-            @NotBlank @RequestParam("code") String code
-    ) {
+    public void kakaoLoginAndRedirect(
+            @NotBlank @RequestParam("code") String code,
+            HttpServletResponse response
+    ) throws IOException {
         TokenResult result = kakaoLoginService.login(code);
-        return RspTemplate.success(Success.CREATE_JWT_TOKEN_SUCCESS, result);
+        Cookie accessTokenCookie = new Cookie("accessToken", result.tokenDto().accessToken());
+        accessTokenCookie.setPath("/");
+        accessTokenCookie.setHttpOnly(true);
+        accessTokenCookie.setMaxAge(60 * 60 * 24);
+
+        Cookie refreshTokenCookie = new Cookie("refreshToken", result.tokenDto().refreshToken());
+        refreshTokenCookie.setPath("/");
+        refreshTokenCookie.setHttpOnly(true);
+        refreshTokenCookie.setMaxAge(60 * 60 * 24 * 7);
+
+        response.addCookie(accessTokenCookie);
+        response.addCookie(refreshTokenCookie);
+
+        String redirectUrl = String.format(
+                "http://localhost:3000/auth/kakao/callback?isNewUser=%b",
+                result.isNewUser()
+        );
+        response.sendRedirect(redirectUrl);
     }
 }

--- a/src/main/java/com/project/zighang/oauth2/controller/KakaoLoginController.java
+++ b/src/main/java/com/project/zighang/oauth2/controller/KakaoLoginController.java
@@ -7,6 +7,7 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -20,6 +21,9 @@ import java.io.IOException;
 public class KakaoLoginController {
 
     private final KakaoLoginService kakaoLoginService;
+
+    @Value("${login.redirect-url.frontend}")
+    private String frontendRedirectUrl;
 
     @GetMapping
     @Operation(
@@ -49,7 +53,8 @@ public class KakaoLoginController {
         response.addCookie(refreshTokenCookie);
 
         String redirectUrl = String.format(
-                "http://localhost:3000/auth/kakao/callback?isNewUser=%b",
+                "%s?isNewUser=%b",
+                frontendRedirectUrl,
                 result.isNewUser()
         );
         response.sendRedirect(redirectUrl);

--- a/src/main/java/com/project/zighang/oauth2/service/JwtAuthenticationFilter.java
+++ b/src/main/java/com/project/zighang/oauth2/service/JwtAuthenticationFilter.java
@@ -2,6 +2,7 @@ package com.project.zighang.oauth2.service;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -34,6 +35,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
             return bearerToken.substring(7);
         }
+
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("accessToken".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+
         return null;
     }
 }

--- a/src/main/java/com/project/zighang/oauth2/service/TokenProvider.java
+++ b/src/main/java/com/project/zighang/oauth2/service/TokenProvider.java
@@ -11,6 +11,8 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 import java.security.Key;
 import java.util.Collections;
@@ -25,9 +27,12 @@ public class TokenProvider {
     private final long accessTokenValidityTime;
     private final long refreshTokenValidityTime;
 
+    private final UserDetailsService userDetailsService;
+
     public TokenProvider(@Value("${jwt.secret}") String secretKey,
                          @Value("${jwt.access-token-validity-in-milliseconds}") long accessTokenValidityTime,
-                         @Value("${jwt.refresh-token-validity-in-milliseconds}") long refreshTokenValidityTime) {
+                         @Value("${jwt.refresh-token-validity-in-milliseconds}") long refreshTokenValidityTime, UserDetailsService userDetailsService) {
+        this.userDetailsService = userDetailsService;
         byte[] keyBytes = Decoders.BASE64.decode(secretKey);
         this.key = Keys.hmacShaKeyFor(keyBytes);
         this.accessTokenValidityTime = accessTokenValidityTime;
@@ -58,13 +63,9 @@ public class TokenProvider {
 
     public Authentication getAuthentication(String accessToken) {
         Claims claims = parseClaims(accessToken);
-
-        // 권한이 없으므로 빈 리스트를 전달
-        List<GrantedAuthority> authorities = Collections.emptyList();
-
-        User principal = new User(claims.getSubject(), "", authorities);
-
-        return new UsernamePasswordAuthenticationToken(principal, "", principal.getAuthorities());
+        String userId = claims.getSubject();
+        UserDetails userDetails = userDetailsService.loadUserByUsername(userId);
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
     }
 
     private Claims parseClaims(String accessToken) {

--- a/src/main/java/com/project/zighang/post/controller/PostController.java
+++ b/src/main/java/com/project/zighang/post/controller/PostController.java
@@ -1,16 +1,21 @@
 package com.project.zighang.post.controller;
 
+import com.project.zighang.global.exception.Error;
 import com.project.zighang.global.exception.Success;
+import com.project.zighang.global.exception.model.NotFoundException;
 import com.project.zighang.global.template.RspTemplate;
 import com.project.zighang.post.dto.PageDto;
 import com.project.zighang.post.dto.PostApplyJobDto;
 import com.project.zighang.post.dto.PostResponseDto;
 import com.project.zighang.post.service.PostService;
+import com.project.zighang.user.entity.UserEntity;
+import com.project.zighang.user.service.UserDetailsImpl;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -41,18 +46,28 @@ public class PostController {
     @GetMapping("/today-apply")
     @Operation(summary = "오늘의 추천 공고 목록 조회")
     public RspTemplate<?> getTodayApplyPosts(
-            @RequestParam Long userId
+            @AuthenticationPrincipal UserDetailsImpl userDetails
     ) {
-        List<PostResponseDto> todayApplyPosts = postService.getTodayApplyPostList(userId);
+        UserEntity loginUser = getUserEntityFromUserDetailsImpl(userDetails);
+        List<PostResponseDto> todayApplyPosts = postService.getTodayApplyPostList(loginUser);
         return RspTemplate.success(Success.GET_API_REQUEST_SUCCESS, todayApplyPosts);
     }
 
     @PostMapping("/apply")
     @Operation(summary = "공고 지원", description = "이미 지원한 공고는 다시 지원할 수 없습니다.")
     public RspTemplate<?> applyInJobPost(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
             @RequestBody PostApplyJobDto request
     ) {
-        postService.applyJobPost(request);
+        UserEntity loginUser = getUserEntityFromUserDetailsImpl(userDetails);
+        postService.applyJobPost(request, loginUser);
         return RspTemplate.success(Success.POST_JOB_APPLY);
+    }
+
+    private UserEntity getUserEntityFromUserDetailsImpl(UserDetailsImpl userDetails) throws RuntimeException {
+        if (userDetails == null) {
+            throw new NotFoundException(com.project.zighang.global.exception.Error.NOT_FOUND_USER, Error.NOT_FOUND_USER.getMessage());
+        }
+        return userDetails.getUserEntity();
     }
 }

--- a/src/main/java/com/project/zighang/post/controller/PostController.java
+++ b/src/main/java/com/project/zighang/post/controller/PostController.java
@@ -9,7 +9,7 @@ import com.project.zighang.post.dto.PostApplyJobDto;
 import com.project.zighang.post.dto.PostResponseDto;
 import com.project.zighang.post.service.PostService;
 import com.project.zighang.user.entity.UserEntity;
-import com.project.zighang.user.service.UserDetailsImpl;
+import com.project.zighang.user.entity.UserDetailsImpl;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/src/main/java/com/project/zighang/post/dto/PostApplyJobDto.java
+++ b/src/main/java/com/project/zighang/post/dto/PostApplyJobDto.java
@@ -1,6 +1,6 @@
 package com.project.zighang.post.dto;
 
 public record PostApplyJobDto(
-        Long userId, Long recruitmentId
+        Long recruitmentId
 ) {
 }

--- a/src/main/java/com/project/zighang/post/service/PostService.java
+++ b/src/main/java/com/project/zighang/post/service/PostService.java
@@ -2,13 +2,14 @@ package com.project.zighang.post.service;
 
 import com.project.zighang.post.dto.PostApplyJobDto;
 import com.project.zighang.post.dto.PostResponseDto;
+import com.project.zighang.user.entity.UserEntity;
 import org.springframework.data.domain.Page;
 
 import java.util.List;
 
 public interface PostService {
     Page<PostResponseDto> getAllPostList(int page, int size);
-    List<PostResponseDto> getTodayApplyPostList(Long userId);
+    List<PostResponseDto> getTodayApplyPostList(UserEntity loginUser);
 
-    void applyJobPost(PostApplyJobDto request);
+    void applyJobPost(PostApplyJobDto request, UserEntity loginUser);
 }

--- a/src/main/java/com/project/zighang/post/service/PostServiceImpl.java
+++ b/src/main/java/com/project/zighang/post/service/PostServiceImpl.java
@@ -45,12 +45,8 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public List<PostResponseDto> getTodayApplyPostList(Long userId) {
-        UserEntity userEntity = userRepository.findById(userId).orElseThrow(
-                () -> new NotFoundException(
-                        Error.NOT_FOUND_USER, com.project.zighang.global.exception.Error.NOT_FOUND_USER.getMessage())
-        );
-        UserOnboardingEntity userOnboardingEntity = userOnboardingRepository.findByUserEntity(userEntity).orElseThrow(
+    public List<PostResponseDto> getTodayApplyPostList(UserEntity loginUser) {
+        UserOnboardingEntity userOnboardingEntity = userOnboardingRepository.findByUserEntity(loginUser).orElseThrow(
                 () -> new NotFoundException(
                         Error.NOT_FOUND_USER_ONBOARDING, Error.NOT_FOUND_USER_ONBOARDING.getMessage())
         );
@@ -67,19 +63,16 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public void applyJobPost(PostApplyJobDto request) {
-        UserEntity userEntity = userRepository.findById(request.userId()).orElseThrow(
-                () -> new NotFoundException(Error.NOT_FOUND_USER, Error.NOT_FOUND_USER.getMessage())
-        );
+    public void applyJobPost(PostApplyJobDto request, UserEntity loginUser) {
         PostEntity postEntity = postEntityRepository.findById(request.recruitmentId()).orElseThrow(
                 () -> new NotFoundException(Error.NOT_FOUND_POST, Error.NOT_FOUND_POST.getMessage())
         );
 
-        if (postApplyEntityRepository.existsByUserEntityAndPostEntity(userEntity, postEntity)) {
+        if (postApplyEntityRepository.existsByUserEntityAndPostEntity(loginUser, postEntity)) {
             throw new BadRequestException(Error.BAD_REQUEST_ALREADY_APPLIED, Error.BAD_REQUEST_ALREADY_APPLIED.getMessage());
         }
 
-        postApplyEntityRepository.save(PostApplyEntity.create(userEntity, postEntity));
+        postApplyEntityRepository.save(PostApplyEntity.create(loginUser, postEntity));
     }
 
     private Page<PostEntity> findPostsByViewCount(Pageable pageable) {

--- a/src/main/java/com/project/zighang/user/controller/UserController.java
+++ b/src/main/java/com/project/zighang/user/controller/UserController.java
@@ -7,7 +7,7 @@ import com.project.zighang.global.template.RspTemplate;
 import com.project.zighang.user.dto.PostUserOnboardingDto;
 import com.project.zighang.user.dto.PostUserTodayApplyCountDTO;
 import com.project.zighang.user.entity.UserEntity;
-import com.project.zighang.user.service.UserDetailsImpl;
+import com.project.zighang.user.entity.UserDetailsImpl;
 import com.project.zighang.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;

--- a/src/main/java/com/project/zighang/user/controller/UserController.java
+++ b/src/main/java/com/project/zighang/user/controller/UserController.java
@@ -1,15 +1,20 @@
 package com.project.zighang.user.controller;
 
+import com.project.zighang.global.exception.Error;
 import com.project.zighang.global.exception.Success;
+import com.project.zighang.global.exception.model.NotFoundException;
 import com.project.zighang.global.template.RspTemplate;
 import com.project.zighang.user.dto.PostUserOnboardingDto;
 import com.project.zighang.user.dto.PostUserTodayApplyCountDTO;
+import com.project.zighang.user.entity.UserEntity;
+import com.project.zighang.user.service.UserDetailsImpl;
 import com.project.zighang.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -31,9 +36,11 @@ public class UserController {
             @ApiResponse(responseCode = "404", description = "존재하지 않는 사용자 정보입니다.")
     })
     public RspTemplate<Void> postUserOnboardingInfo(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
             @RequestBody PostUserOnboardingDto postUserOnboardingDto
     ) {
-        userService.addUserOnboardingInfo(postUserOnboardingDto);
+        UserEntity loginUser = getUserEntityFromUserDetailsImpl(userDetails);
+        userService.addUserOnboardingInfo(postUserOnboardingDto, loginUser);
         return RspTemplate.success(Success.POST_USER_Onboarding_API_REQUEST_SUCCESS);
     }
 
@@ -42,9 +49,18 @@ public class UserController {
             summary = "사용자 오늘의 지원 개수 정보 저장"
     )
     public RspTemplate<?> postUserTodayApplyCount(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
             @RequestBody PostUserTodayApplyCountDTO dto
     ) {
-        userService.setUserApplyCount(dto);
+        UserEntity loginUser = getUserEntityFromUserDetailsImpl(userDetails);
+        userService.setUserApplyCount(dto, loginUser);
         return RspTemplate.success(Success.POST_USER_APPLY_COUNT_API_REQUEST_SUCCESS);
+    }
+
+    private UserEntity getUserEntityFromUserDetailsImpl(UserDetailsImpl userDetails) throws RuntimeException {
+        if (userDetails == null) {
+            throw new NotFoundException(Error.NOT_FOUND_USER, Error.NOT_FOUND_USER.getMessage());
+        }
+        return userDetails.getUserEntity();
     }
 }

--- a/src/main/java/com/project/zighang/user/dto/PostUserOnboardingDto.java
+++ b/src/main/java/com/project/zighang/user/dto/PostUserOnboardingDto.java
@@ -6,8 +6,8 @@ import jakarta.validation.constraints.Min;
 import java.util.List;
 
 public record PostUserOnboardingDto(
-        @Schema(description = "사용자 ID (토큰 구현 전까지 임시 사용)", example = "1")
-        Long userId,
+//        @Schema(description = "사용자 ID (토큰 구현 전까지 임시 사용)", example = "1")
+//        Long userId,
 
         @Schema(description = "최소 경력 연차 (신입: 0, 1년차: 1, 2년차: 2...)", example = "3") @Min(0)
         Long minCareer,

--- a/src/main/java/com/project/zighang/user/dto/PostUserTodayApplyCountDTO.java
+++ b/src/main/java/com/project/zighang/user/dto/PostUserTodayApplyCountDTO.java
@@ -3,7 +3,6 @@ package com.project.zighang.user.dto;
 import jakarta.validation.constraints.NotNull;
 
 public record PostUserTodayApplyCountDTO(
-        Long userId,
         @NotNull Long applyCount
 ) {
 }

--- a/src/main/java/com/project/zighang/user/entity/UserDetailsImpl.java
+++ b/src/main/java/com/project/zighang/user/entity/UserDetailsImpl.java
@@ -1,6 +1,5 @@
-package com.project.zighang.user.service;
+package com.project.zighang.user.entity;
 
-import com.project.zighang.user.entity.UserEntity;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;

--- a/src/main/java/com/project/zighang/user/service/UserDetailsImpl.java
+++ b/src/main/java/com/project/zighang/user/service/UserDetailsImpl.java
@@ -1,0 +1,45 @@
+package com.project.zighang.user.service;
+
+import com.project.zighang.user.entity.UserEntity;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@Getter
+@RequiredArgsConstructor
+public class UserDetailsImpl implements UserDetails {
+
+    private final UserEntity userEntity;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        // 역할(Role) 기반 권한이 필요하다면 여기에 로직을 추가합니다.
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String getPassword() {
+        return null; // JWT 방식에서는 사용하지 않습니다.
+    }
+
+    @Override
+    public String getUsername() {
+        return String.valueOf(userEntity.getId());
+    }
+
+    @Override
+    public boolean isAccountNonExpired() { return true; }
+
+    @Override
+    public boolean isAccountNonLocked() { return true; }
+
+    @Override
+    public boolean isCredentialsNonExpired() { return true; }
+
+    @Override
+    public boolean isEnabled() { return true; }
+}

--- a/src/main/java/com/project/zighang/user/service/UserDetailsServiceImpl.java
+++ b/src/main/java/com/project/zighang/user/service/UserDetailsServiceImpl.java
@@ -2,6 +2,7 @@ package com.project.zighang.user.service;
 
 import com.project.zighang.global.exception.Error;
 import com.project.zighang.global.exception.model.NotFoundException;
+import com.project.zighang.user.entity.UserDetailsImpl;
 import com.project.zighang.user.entity.UserEntity;
 import com.project.zighang.user.repository.UserRepository;
 

--- a/src/main/java/com/project/zighang/user/service/UserDetailsServiceImpl.java
+++ b/src/main/java/com/project/zighang/user/service/UserDetailsServiceImpl.java
@@ -1,0 +1,27 @@
+package com.project.zighang.user.service;
+
+import com.project.zighang.global.exception.Error;
+import com.project.zighang.global.exception.model.NotFoundException;
+import com.project.zighang.user.entity.UserEntity;
+import com.project.zighang.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String userId) throws NotFoundException {
+        UserEntity user = userRepository.findById(Long.parseLong(userId))
+                .orElseThrow(() -> new NotFoundException(Error.NOT_FOUND_USER, Error.NOT_FOUND_USER.getMessage()));
+
+        return new UserDetailsImpl(user);
+    }
+}

--- a/src/main/java/com/project/zighang/user/service/UserService.java
+++ b/src/main/java/com/project/zighang/user/service/UserService.java
@@ -2,8 +2,9 @@ package com.project.zighang.user.service;
 
 import com.project.zighang.user.dto.PostUserOnboardingDto;
 import com.project.zighang.user.dto.PostUserTodayApplyCountDTO;
+import com.project.zighang.user.entity.UserEntity;
 
 public interface UserService {
-    void addUserOnboardingInfo(PostUserOnboardingDto request);
-    void setUserApplyCount(PostUserTodayApplyCountDTO request);
+    void addUserOnboardingInfo(PostUserOnboardingDto request, UserEntity loginUser);
+    void setUserApplyCount(PostUserTodayApplyCountDTO request, UserEntity loginUser);
 }

--- a/src/main/java/com/project/zighang/user/service/UserServiceImpl.java
+++ b/src/main/java/com/project/zighang/user/service/UserServiceImpl.java
@@ -33,13 +33,7 @@ public class UserServiceImpl implements UserService {
     private final IndustryRepository industryRepository;
 
     @Override
-    public void addUserOnboardingInfo(PostUserOnboardingDto request) {
-        Long userId = request.userId();
-        // User Entity 유무 확인, User Entity는 소셜 로그인 과정에서 생성되어 디비에 저장됨
-        UserEntity userEntity = userRepository.findById(userId).orElseThrow(
-                () -> new NotFoundException(Error.NOT_FOUND_USER, Error.NOT_FOUND_USER.getMessage())
-        );
-
+    public void addUserOnboardingInfo(PostUserOnboardingDto request, UserEntity loginUser) {
         Long minCareer = request.minCareer();
         Long maxCareer = request.maxCareer();
         if (minCareer == null || minCareer < 0 || maxCareer == null || maxCareer < 0) {
@@ -50,49 +44,45 @@ public class UserServiceImpl implements UserService {
         }
 
         // Onboarding Entity
-        userOnboardingRepository.findByUserEntity(userEntity)
+        userOnboardingRepository.findByUserEntity(loginUser)
                 .ifPresentOrElse(
                         onboardingEntity -> {
-                            log.error("이미 온보딩 정보가 존재합니다. userId: {}", userId);
+                            log.error("이미 온보딩 정보가 존재합니다. userId: {}", loginUser.getId());
                         }, () -> {
-                            log.info("온보딩 정보가 없어 새로 저장합니다. userId: {}", userId);
+                            log.info("온보딩 정보가 없어 새로 저장합니다. userId: {}", loginUser.getId());
                             UserOnboardingEntity userOnboardingEntity = UserOnboardingEntity.create(
-                                    userEntity, request.minCareer(), request.maxCareer());
+                                    loginUser, request.minCareer(), request.maxCareer());
                             userOnboardingRepository.save(userOnboardingEntity);
                             log.info("새로운 온보딩 정보를 저장했습니다.");
                         }
                 );
 
         // Address Entity
-        addressRepository.deleteAllByUserEntity(userEntity);
+        addressRepository.deleteAllByUserEntity(loginUser);
 
         List<AddressEntity> newAddresses = request.addressList().stream()
-                .map(dto -> AddressEntity.create(dto.city(), dto.district(), userEntity))
+                .map(dto -> AddressEntity.create(dto.city(), dto.district(), loginUser))
                 .collect(Collectors.toList());
 
         addressRepository.saveAll(newAddresses);
 
         // Industry Entity
-        industryRepository.deleteAllByUserEntity(userEntity);
+        industryRepository.deleteAllByUserEntity(loginUser);
 
         List<IndustryEntity> newIndustries = request.industryList().stream()
-                .map(dto -> IndustryEntity.create(dto.jobFamily(), dto.role(), userEntity))
+                .map(dto -> IndustryEntity.create(dto.jobFamily(), dto.role(), loginUser))
                 .collect(Collectors.toList());
 
         industryRepository.saveAll(newIndustries);
     }
 
     @Override
-    public void setUserApplyCount(PostUserTodayApplyCountDTO request) {
+    public void setUserApplyCount(PostUserTodayApplyCountDTO request, UserEntity loginUser) {
         if (request.applyCount() < 0) {
             throw  new BadRequestException(Error.BAD_REQUEST_APPLY_COUNT_VALUE, Error.BAD_REQUEST_APPLY_COUNT_VALUE.getMessage());
         }
 
-        Long userId = request.userId();
-        UserEntity userEntity = userRepository.findById(userId).orElseThrow(
-                () -> new NotFoundException(Error.NOT_FOUND_USER, Error.NOT_FOUND_USER.getMessage())
-        );
-        UserOnboardingEntity userOnboardingEntity = userOnboardingRepository.findByUserEntity(userEntity).orElseThrow(
+        UserOnboardingEntity userOnboardingEntity = userOnboardingRepository.findByUserEntity(loginUser).orElseThrow(
                 () -> new NotFoundException(Error.NOT_FOUND_USER_ONBOARDING, Error.NOT_FOUND_USER_ONBOARDING.getMessage())
         );
 


### PR DESCRIPTION
## 기능 설명
- 카카오 소셜 로그인 성공 시 토큰을 쿠키에 넣어 redirect url을 내리도록 수정했습니다.
- JwtAuthenticationFilter 클래스의 resolveToken 메소드에서 헤더의 토큰 값 확인과 쿠키의 토큰 값 확인하는 로직을 추가했습니다.
- userId를 API Request로 받지 않고 @AuthenticationPrincipal로 userEntity 가져오도록 수정했습니다.
- 기존에 userId를 API Request로 받던 부분을 모두 @AuthenticationPrincipal로 수정했습니다.

## 연결된 issue

close #35 

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 카카오 로그인 성공 시 액세스/리프레시 토큰을 HttpOnly 쿠키로 발급하고 프론트엔드로 리다이렉트(isNewUser 쿼리 포함). 쿠키 기반 인증으로 헤더 없이도 로그인 유지가 동작합니다.
- API Changes
  - 지원 내역 조회/지원하기, 사용자 온보딩/일일 지원횟수 설정 등 사용자 관련 엔드포인트에서 userId 전달이 불필요하며, 로그인 사용자 컨텍스트를 자동 사용합니다.
  - 카카오 로그인은 응답 본문 대신 리다이렉트로 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->