### PR TITLE
[Feat] 사용자 공고 지원 이력 조회 API 구현하다

### DIFF
--- a/src/main/java/com/project/zighang/oauth2/controller/KakaoLoginController.java
+++ b/src/main/java/com/project/zighang/oauth2/controller/KakaoLoginController.java
@@ -3,7 +3,6 @@ package com.project.zighang.oauth2.controller;
 import com.project.zighang.oauth2.dto.TokenResult;
 import com.project.zighang.oauth2.service.KakaoLoginService;
 import io.swagger.v3.oas.annotations.Operation;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
@@ -27,8 +26,6 @@ public class KakaoLoginController {
 
     @Value("${login.redirect-url.frontend}")
     private String frontendRedirectUrl;
-
-    private final boolean useHttps = false;
 
     @GetMapping
     @Operation(
@@ -54,9 +51,8 @@ public class KakaoLoginController {
         response.addHeader("Set-Cookie", refreshTokenCookie.toString());
 
         String redirectUrl = String.format(
-                "%s?isNewUser=%b",
-                frontendRedirectUrl,
-                result.isNewUser()
+                "%s",
+                frontendRedirectUrl
         );
 
         log.info("Redirecting user to: {}", redirectUrl);
@@ -69,15 +65,7 @@ public class KakaoLoginController {
                 .maxAge(maxAge);
 //                .httpOnly(true);
 
-        if (useHttps) {
-            builder.secure(true) // HTTPS 환경에서만 Secure 설정
-                    .sameSite("None"); // Cross-Origin 통신을 위해 None 설정
-        } else {
-            // HTTP 환경에서는 SameSite=None을 설정할 수 없으므로,
-            // 기본값(Lax)을 사용하거나 명시적으로 Lax로 설정합니다.
-            builder.sameSite("Lax");
-        }
-
+        builder.secure(true).sameSite("None");
         return builder.build();
     }
 }

--- a/src/main/java/com/project/zighang/post/controller/PostController.java
+++ b/src/main/java/com/project/zighang/post/controller/PostController.java
@@ -64,6 +64,16 @@ public class PostController {
         return RspTemplate.success(Success.POST_JOB_APPLY);
     }
 
+    @GetMapping("/apply-history")
+    @Operation(summary = "지난 지원 목록 조회")
+    public RspTemplate<?> getUserApplyHistory(
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        UserEntity loginUser = getUserEntityFromUserDetailsImpl(userDetails);
+        List<PostResponseDto> userApplyHistory = postService.getAllUserApplyHistory(loginUser);
+        return RspTemplate.success(Success.GET_API_REQUEST_SUCCESS, userApplyHistory);
+    }
+
     private UserEntity getUserEntityFromUserDetailsImpl(UserDetailsImpl userDetails) throws RuntimeException {
         if (userDetails == null) {
             throw new NotFoundException(com.project.zighang.global.exception.Error.NOT_FOUND_USER, Error.NOT_FOUND_USER.getMessage());

--- a/src/main/java/com/project/zighang/post/repository/PostApplyEntityRepository.java
+++ b/src/main/java/com/project/zighang/post/repository/PostApplyEntityRepository.java
@@ -4,9 +4,17 @@ import com.project.zighang.post.entity.PostApplyEntity;
 import com.project.zighang.post.entity.PostEntity;
 import com.project.zighang.user.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface PostApplyEntityRepository extends JpaRepository<PostApplyEntity, Long> {
+
     boolean existsByUserEntityAndPostEntity(UserEntity userEntity, PostEntity postEntity);
+
+    @Query("SELECT pa FROM PostApplyEntity pa JOIN FETCH pa.postEntity WHERE pa.userEntity = :user")
+    List<PostApplyEntity> findAllByUserEntityWithPostFetch(@Param("user") UserEntity user);
 }

--- a/src/main/java/com/project/zighang/post/service/PostService.java
+++ b/src/main/java/com/project/zighang/post/service/PostService.java
@@ -10,6 +10,7 @@ import java.util.List;
 public interface PostService {
     Page<PostResponseDto> getAllPostList(int page, int size);
     List<PostResponseDto> getTodayApplyPostList(UserEntity loginUser);
+    List<PostResponseDto> getAllUserApplyHistory(UserEntity loginUser);
 
     void applyJobPost(PostApplyJobDto request, UserEntity loginUser);
 }

--- a/src/main/java/com/project/zighang/post/service/PostServiceImpl.java
+++ b/src/main/java/com/project/zighang/post/service/PostServiceImpl.java
@@ -22,6 +22,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -30,7 +31,6 @@ public class PostServiceImpl implements PostService {
 
     private final PostEntityRepository postEntityRepository;
     private final UserOnboardingRepository userOnboardingRepository;
-    private final UserRepository userRepository;
     private final PostApplyEntityRepository postApplyEntityRepository;
 
     private static final int MAX_SIZE = 50;
@@ -60,6 +60,15 @@ public class PostServiceImpl implements PostService {
         }
 
         return List.of();
+    }
+
+    @Override
+    public List<PostResponseDto> getAllUserApplyHistory(UserEntity loginUser) {
+        List<PostApplyEntity> postApplyEntityList = postApplyEntityRepository.findAllByUserEntityWithPostFetch(loginUser);
+        return postApplyEntityList.stream()
+                .map(PostApplyEntity::getPostEntity)
+                .map(PostResponseDto::from)
+                .toList();
     }
 
     @Override


### PR DESCRIPTION
## 기능 설명
- 사용자 공고 지원 이력 조회 API 구현
- 카카오 소셜 로그인 쿠키 생성 로직 수정

swagger 테스트 성공 결과 스크린샷 첨부
<img width="1158" height="766" alt="스크린샷 2025-09-06 오후 3 58 24" src="https://github.com/user-attachments/assets/cbdbec94-02af-4a1c-83f5-36942475c70b" />


## 연결된 issue

close #56 
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 지난 지원 내역 조회 기능 추가: 로그인 사용자가 과거 지원한 공고 목록을 확인할 수 있습니다.
- 버그 수정
  - 카카오 로그인 리다이렉트에서 불필요한 쿼리 파라미터 제거로 URL이 간결해졌습니다.
  - 인증 쿠키를 Secure 및 SameSite=None로 일관 적용하여 크로스 도메인 환경에서 로그인/세션 안정성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->