### PR TITLE
[Fix] onboarding api 수정 사항 반영하다

### DIFF
--- a/src/main/java/com/project/zighang/oauth2/controller/KakaoLoginController.java
+++ b/src/main/java/com/project/zighang/oauth2/controller/KakaoLoginController.java
@@ -2,6 +2,7 @@ package com.project.zighang.oauth2.controller;
 
 import com.project.zighang.oauth2.dto.TokenResult;
 import com.project.zighang.oauth2.service.KakaoLoginService;
+import feign.template.UriUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.constraints.NotBlank;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.http.ResponseCookie;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 @Slf4j
 @RestController
@@ -42,7 +44,7 @@ public class KakaoLoginController {
     ) throws IOException {
         log.info("Kakao login callback received. Authorization code processed.");
         TokenResult result = kakaoLoginService.login(code);
-        log.info("Kakao login successful. New user status: {}", result.isNewUser());
+        log.info("Kakao login successful. New user status: {}", result.userName());
 
         ResponseCookie accessTokenCookie = createCookie("accessToken", result.tokenDto().accessToken(), 60 * 60 * 24);
         ResponseCookie refreshTokenCookie = createCookie("refreshToken", result.tokenDto().refreshToken(), 60 * 60 * 24 * 7);
@@ -50,9 +52,11 @@ public class KakaoLoginController {
         response.addHeader("Set-Cookie", accessTokenCookie.toString());
         response.addHeader("Set-Cookie", refreshTokenCookie.toString());
 
+        String encodedName = UriUtils.encode(result.userName(), StandardCharsets.UTF_8);
+
         String redirectUrl = String.format(
-                "%s",
-                frontendRedirectUrl
+                "%s?%s=%s",
+                frontendRedirectUrl, "name", encodedName
         );
 
         log.info("Redirecting user to: {}", redirectUrl);

--- a/src/main/java/com/project/zighang/oauth2/dto/TokenResult.java
+++ b/src/main/java/com/project/zighang/oauth2/dto/TokenResult.java
@@ -1,7 +1,7 @@
 package com.project.zighang.oauth2.dto;
 
-public record TokenResult(TokenDto tokenDto, Boolean isNewUser) {
-    public static TokenResult from(final TokenDto tokenDto, boolean isNewUser){
-        return new TokenResult(tokenDto, isNewUser);
+public record TokenResult(TokenDto tokenDto, String userName) {
+    public static TokenResult from(final TokenDto tokenDto, String userName){
+        return new TokenResult(tokenDto, userName);
     }
 }

--- a/src/main/java/com/project/zighang/oauth2/service/UserAuthService.java
+++ b/src/main/java/com/project/zighang/oauth2/service/UserAuthService.java
@@ -32,12 +32,12 @@ public class UserAuthService {
 
         if (existingToken.isPresent() && tokenProvider.validateToken(existingToken.get().getAccessToken())) {
             TokenDto tokenDto = TokenDto.of(existingToken.get().getAccessToken(), existingToken.get().getRefreshToken());
-            return new TokenResult(tokenDto, loginResult.isNewUser());
+            return new TokenResult(tokenDto, loginResult.user().getName());
         }
 
         TokenDto newTokenDto = tokenProvider.createToken(user);
         upsertTokenEntity(newTokenDto, user);
-        return new TokenResult(newTokenDto, loginResult.isNewUser());
+        return new TokenResult(newTokenDto, loginResult.user().getName());
     }
 
     private LoginResult loginOrSignUp(KakaoUserInfoResponseDto userInfo) {

--- a/src/main/java/com/project/zighang/user/controller/UserController.java
+++ b/src/main/java/com/project/zighang/user/controller/UserController.java
@@ -6,6 +6,7 @@ import com.project.zighang.global.exception.model.NotFoundException;
 import com.project.zighang.global.template.RspTemplate;
 import com.project.zighang.user.dto.PostUserOnboardingDto;
 import com.project.zighang.user.dto.PostUserTodayApplyCountDTO;
+import com.project.zighang.user.dto.UserStatusDto;
 import com.project.zighang.user.entity.UserEntity;
 import com.project.zighang.user.entity.UserDetailsImpl;
 import com.project.zighang.user.service.UserService;
@@ -44,6 +45,18 @@ public class UserController {
         userService.addUserOnboardingInfo(postUserOnboardingDto, loginUser);
         log.info("SUCCESS postUserOnboardingInfo for user: {}", loginUser.getId());
         return RspTemplate.success(Success.POST_USER_Onboarding_API_REQUEST_SUCCESS);
+    }
+
+    @GetMapping("/status")
+    @Operation(
+            summary = "사용자 온보딩 상태 정보 조회"
+    )
+    public RspTemplate<?> getUserStatus(
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        UserEntity loginUser = getUserEntityFromUserDetailsImpl(userDetails);
+        boolean isUserOnboarded = userService.isUserOnboarded(loginUser);
+        return RspTemplate.success(Success.GET_API_REQUEST_SUCCESS, new UserStatusDto(isUserOnboarded));
     }
 
     @PostMapping("/today-apply")

--- a/src/main/java/com/project/zighang/user/dto/UserStatusDto.java
+++ b/src/main/java/com/project/zighang/user/dto/UserStatusDto.java
@@ -1,0 +1,6 @@
+package com.project.zighang.user.dto;
+
+public record UserStatusDto(
+        boolean isOnboarded
+) {
+}

--- a/src/main/java/com/project/zighang/user/repository/UserOnboardingRepository.java
+++ b/src/main/java/com/project/zighang/user/repository/UserOnboardingRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 @Repository
 public interface UserOnboardingRepository extends JpaRepository<UserOnboardingEntity, Long> {
     Optional<UserOnboardingEntity> findByUserEntity(UserEntity userEntity);
+    boolean existsByUserEntity(UserEntity userEntity);
 }

--- a/src/main/java/com/project/zighang/user/service/UserService.java
+++ b/src/main/java/com/project/zighang/user/service/UserService.java
@@ -7,4 +7,5 @@ import com.project.zighang.user.entity.UserEntity;
 public interface UserService {
     void addUserOnboardingInfo(PostUserOnboardingDto request, UserEntity loginUser);
     void setUserApplyCount(PostUserTodayApplyCountDTO request, UserEntity loginUser);
+    boolean isUserOnboarded(UserEntity loginUser);
 }

--- a/src/main/java/com/project/zighang/user/service/UserServiceImpl.java
+++ b/src/main/java/com/project/zighang/user/service/UserServiceImpl.java
@@ -88,4 +88,9 @@ public class UserServiceImpl implements UserService {
 
         userOnboardingEntity.updateDailyRecommendPostCount(request.applyCount());
     }
+
+    @Override
+    public boolean isUserOnboarded(UserEntity loginUser) {
+        return userOnboardingRepository.existsByUserEntity(loginUser);
+    }
 }


### PR DESCRIPTION
## 기능 설명
- 소셜 로그인 redirect url 수정
- 소셜 로그인 redirect url에 쿼리 파라미터로 사용자 이름 추가
- 온보딩 유무를 확인하는 GET API 구현

swagger 테스트 성공 결과 스크린샷 첨부
<img width="1448" height="726" alt="스크린샷 2025-09-07 오후 5 29 18" src="https://github.com/user-attachments/assets/2d711f48-d331-4ade-a15d-72ba824481ef" />

## 연결된 issue

close #62 
<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 사용자 온보딩 상태 조회 API 추가: GET /v1/user/status. 응답에 isOnboarded 플래그를 포함해 현재 계정의 온보딩 완료 여부를 제공합니다.
  * 카카오 로그인 완료 후 프론트엔드 리다이렉트 시 사용자 이름을 URL 인코딩하여 name 쿼리 파라미터로 전달합니다(예: ?name=홍길동).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->