### PR TITLE
REFACTOR: 기업구독 정보를 응답에 포함시킨다

### DIFF
--- a/src/main/java/com/project/zighang/domain/company/controller/CompanyController.java
+++ b/src/main/java/com/project/zighang/domain/company/controller/CompanyController.java
@@ -7,8 +7,12 @@ import com.project.zighang.domain.company.enumerate.JobGroup;
 import com.project.zighang.domain.company.service.CompanyQueryService;
 import com.project.zighang.global.exception.Success;
 import com.project.zighang.global.template.RspTemplate;
+import com.project.zighang.user.entity.UserDetailsImpl;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.*;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Set;
@@ -21,32 +25,42 @@ public class CompanyController {
 
     private final CompanyQueryService companyQueryService;
 
-    // 예:
-    // /api/companies/search-with-news?types=LARGE_ENTERPRISE&jobGroups=DATA_AI&regionCodes=SEOUL&page=0&size=20
     @GetMapping
-    public Page<CompanyWithNewsResponse> searchWithNews(
+    @Operation(summary = "기업 필터링", description = "기업을 뉴스와 함께 필터링하여 조회합니다.")
+    public RspTemplate<Page<CompanyWithNewsResponse>> searchWithNews(
             @RequestParam(required = false) Set<CompanyType> types,
             @RequestParam(required = false) Set<JobGroup> jobGroups,
             @RequestParam(required = false) Set<String> regionCodes,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size,
-            @RequestParam(defaultValue = "companyNameKr,asc") String sort
-    ) {
+            @RequestParam(defaultValue = "companyNameKr,asc") String sort,
+            @AuthenticationPrincipal UserDetailsImpl userDetails)
+    {
         String[] s = sort.split(",", 2);
-        Sort springSort = Sort.by(Sort.Direction.fromString(s.length > 1 ? s[1] : "asc"),
-                s[0]);
+        Sort springSort = Sort.by(Sort.Direction.fromString(s.length > 1 ? s[1] : "asc"), s[0]);
         Pageable pageable = PageRequest.of(page, size, springSort);
-        return companyQueryService.searchWithNews(types, jobGroups, regionCodes, pageable);
+
+        Long userId = userDetails != null ? userDetails.getId() : null;
+
+        return RspTemplate.success(Success.GET_API_REQUEST_SUCCESS, companyQueryService.searchWithNews(types, jobGroups, regionCodes, pageable, userId));
     }
 
-    /** 상세: 회사 전체 뉴스 + 같은 타입 랜덤 3사(각 3뉴스) */
     @GetMapping("/{companyId}")
-    public CompanyDetailWithSimilarResponse getDetail(@PathVariable Long companyId) {
-        return companyQueryService.getDetailWithNewsAndSimilar(companyId);
+    @Operation(summary = "기업뉴스 상세조회", description = "기업 뉴스와 함께, 같은 타입의 유사 기업 3곳을 랜덤으로 조회합니다.")
+    public RspTemplate<CompanyDetailWithSimilarResponse> getDetail(@PathVariable Long companyId,
+                                                      @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        Long userId = userDetails != null ? userDetails.getId() : null;
+
+        return RspTemplate.success(Success.GET_API_REQUEST_SUCCESS, companyQueryService.getDetailWithNewsAndSimilar(companyId, userId));
     }
 
-    @GetMapping("{userId}/subscriptions")
-    public RspTemplate<List<CompanyWithNewsResponse>> getSubscribedCompaniesWithNews(@PathVariable Long userId) {
-        return RspTemplate.success(Success.SUBSCRIBE_SUCCESS, companyQueryService.getSubscribedCompaniesWithNews(userId));
+    @GetMapping("/subscriptions")
+    @Operation(summary = "구독한 회사들 조회", description = "구독한 회사들의 정보와 최신 뉴스를 조회합니다.")
+    public RspTemplate<List<CompanyWithNewsResponse>> getSubscribedCompaniesWithNews(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        Long userId = userDetails != null ? userDetails.getId() : null;
+
+        return RspTemplate.success(Success.GET_API_REQUEST_SUCCESS, companyQueryService.getSubscribedCompaniesWithNews(userId));
     }
 }

--- a/src/main/java/com/project/zighang/domain/company/dto/CompanyThumbnail.java
+++ b/src/main/java/com/project/zighang/domain/company/dto/CompanyThumbnail.java
@@ -7,5 +7,7 @@ public record CompanyThumbnail(
 
         String companyThumbnailUrl,
 
-        String companyTypeLabel // enum description
+        String companyTypeLabel,
+
+        boolean isSubscribed
 ) {}

--- a/src/main/java/com/project/zighang/domain/company/service/CompanyQueryService.java
+++ b/src/main/java/com/project/zighang/domain/company/service/CompanyQueryService.java
@@ -35,6 +35,10 @@ public class CompanyQueryService {
             return List.of();
         }
 
+        Set<Long> subscribedCompanyIds = userId != null
+                ? Set.copyOf(subscriptionFinder.findSubscribedCompanyIds(userId))
+                : Set.of();
+
         // 회사별 최신 3개 뉴스만 SELECT
         List<CompanyNewsRepository.NewsSliceRow> rows = companyNewsRepository.findTopNewsByCompanyIds(companyIds, 3);
 
@@ -54,7 +58,7 @@ public class CompanyQueryService {
 
         return companies.stream()
                 .map(c -> new CompanyWithNewsResponse(
-                        toCompanyThumb(c),
+                        toCompanyThumb(c, subscribedCompanyIds.contains(c.getId())),
                         newsMap.getOrDefault(c.getId(), List.of())
                 ))
                 .toList();
@@ -65,7 +69,8 @@ public class CompanyQueryService {
             Set<CompanyType> types,
             Set<JobGroup> jobGroups,
             Set<String> regionCodes,
-            Pageable pageable
+            Pageable pageable,
+            Long userId
     ) {
         types       = normalize(types);
         jobGroups   = normalize(jobGroups);
@@ -78,6 +83,11 @@ public class CompanyQueryService {
 
         List<Company> companies = companyPage.getContent();
         List<Long> ids = companies.stream().map(Company::getId).toList();
+
+        // 회원인 경우에만 구독 회사 목록 조회, 비회원은 빈 Set
+        Set<Long> subscribedCompanyIds = userId != null
+                ? Set.copyOf(subscriptionFinder.findSubscribedCompanyIds(userId))
+                : Set.of();
 
         // 회사별 최신 3개 뉴스만 SELECT
         var rows = companyNewsRepository.findTopNewsByCompanyIds(ids, 3);
@@ -93,7 +103,7 @@ public class CompanyQueryService {
 
         List<CompanyWithNewsResponse> content = companies.stream()
                 .map(c -> new CompanyWithNewsResponse(
-                        toCompanyThumb(c),
+                        toCompanyThumb(c, subscribedCompanyIds.contains(c.getId())),
                         newsMap.getOrDefault(c.getId(), List.of())
                 ))
                 .toList();
@@ -102,12 +112,16 @@ public class CompanyQueryService {
     }
 
     /** 상세: 회사 전체 뉴스 + 같은 타입 랜덤 3사(각 3뉴스) */
-    public CompanyDetailWithSimilarResponse getDetailWithNewsAndSimilar(Long companyId) {
+    public CompanyDetailWithSimilarResponse getDetailWithNewsAndSimilar(Long companyId, Long userId) {
         Company company = companyRepository.findById(companyId)
                 .orElseThrow(() -> new NoSuchElementException("Company not found: " + companyId));
 
+        Set<Long> subscribedCompanyIds = userId != null
+                ? Set.copyOf(subscriptionFinder.findSubscribedCompanyIds(userId))
+                : Set.of();
+
         // 회사 요약
-        var companyDto = toCompanyThumb(company);
+        var companyDto = toCompanyThumb(company, subscribedCompanyIds.contains(companyId));
 
         // 전체 뉴스 (최신순)
         var newsEntities = companyNewsRepository.findAllByCompanyIdOrderByPublishedDesc(companyId);
@@ -140,7 +154,7 @@ public class CompanyQueryService {
 
                 similar = similars.stream()
                         .map(s -> new CompanyWithNewsResponse(
-                                toCompanyThumb(s),
+                                toCompanyThumb(s, subscribedCompanyIds.contains(s.getId())),
                                 newsMap.getOrDefault(s.getId(), List.of())
                         ))
                         .toList();
@@ -150,12 +164,13 @@ public class CompanyQueryService {
         return new CompanyDetailWithSimilarResponse(companyDto, newsAll, similar);
     }
 
-    private CompanyThumbnail toCompanyThumb(Company c) {
+    private CompanyThumbnail toCompanyThumb(Company c, boolean isSubscribed) {
         return new CompanyThumbnail(
                 c.getId(),
                 c.getCompanyNameKr(),
                 c.getCompanyThumbnailUrl(),
-                c.getCompanyType() != null ? c.getCompanyType().getDescription() : null
+                c.getCompanyType() != null ? c.getCompanyType().getDescription() : null,
+                isSubscribed
         );
     }
 

--- a/src/main/java/com/project/zighang/domain/subscription/controller/SubscriptionController.java
+++ b/src/main/java/com/project/zighang/domain/subscription/controller/SubscriptionController.java
@@ -6,8 +6,11 @@ import com.project.zighang.domain.subscription.entity.UserCompanySubscription;
 import com.project.zighang.domain.subscription.service.SubscriptionService;
 import com.project.zighang.global.exception.Success;
 import com.project.zighang.global.template.RspTemplate;
+import com.project.zighang.user.entity.UserDetailsImpl;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -20,8 +23,9 @@ public class SubscriptionController {
     private final SubscriptionService subscriptionService;
 
     @PostMapping
-    public RspTemplate<List<SubscriptionResponse>> register(@Valid @RequestBody SubscriptionRequest request) {
-        List<UserCompanySubscription> subscriptions = subscriptionService.register(request.userId(), request.companyId());
+    public RspTemplate<List<SubscriptionResponse>> register(@RequestParam Long companyId,
+                                                            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        List<UserCompanySubscription> subscriptions = subscriptionService.register(userDetails.getId(), companyId);
 
         List<SubscriptionResponse> subscriptionResponse = subscriptions.stream()
                 .map(sub -> new SubscriptionResponse(sub.getId(), sub.getUserId(), sub.getCompanyId()))
@@ -31,8 +35,9 @@ public class SubscriptionController {
     }
 
     @DeleteMapping
-    public RspTemplate<List<SubscriptionResponse>> unregister(@Valid @RequestBody SubscriptionRequest request) {
-        List<UserCompanySubscription> subscriptions = subscriptionService.unregister(request.userId(), request.companyId());
+    public RspTemplate<List<SubscriptionResponse>> unregister(@RequestParam Long companyId,
+                                                              @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        List<UserCompanySubscription> subscriptions = subscriptionService.unregister(userDetails.getId(), companyId);
 
         List<SubscriptionResponse> subscriptionResponse = subscriptions.stream()
                 .map(sub -> new SubscriptionResponse(sub.getId(), sub.getUserId(), sub.getCompanyId()))

--- a/src/main/java/com/project/zighang/user/controller/UserController.java
+++ b/src/main/java/com/project/zighang/user/controller/UserController.java
@@ -30,7 +30,7 @@ public class UserController {
     @Operation(
             summary = "사용자 온보딩 정보 저장",
             description = "사용자의 온보딩 정보(경력, 관심지역 목록, 관심산업 목록)를 저장합니다. "
-+ "기존 저장 데이터가 있으면 모두 삭제 후 새로 받은 정보로 대체합니다."
+                            + "기존 저장 데이터가 있으면 모두 삭제 후 새로 받은 정보로 대체합니다."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "유저 온보딩 POST API 호출에 성공했습니다."),

--- a/src/main/java/com/project/zighang/user/entity/UserDetailsImpl.java
+++ b/src/main/java/com/project/zighang/user/entity/UserDetailsImpl.java
@@ -20,6 +20,10 @@ public class UserDetailsImpl implements UserDetails {
         return Collections.emptyList();
     }
 
+    public Long getId() {
+        return userEntity.getId();
+    }
+
     @Override
     public String getPassword() {
         return null; // JWT 방식에서는 사용하지 않습니다.


### PR DESCRIPTION
## 기능 설명

기업 조회 API에 사용자 인증 정보를 추가하여 구독 여부를 반환하도록 구현했습니다.

### 주요 변경사항

1. **컨트롤러 수정** - `@AuthenticationPrincipal UserDetailsImpl userDetails` 파라미터 추가
2. **서비스 메서드 수정** - `userId` 파라미터를 받아 구독 여부 확인 로직 추가  
3. **DTO 구조 변경** - `CompanyThumbnail`에 `isSubscribed` 필드 추가, `CompanyWithNewsResponse`에서는 제거

### API 동작 방식

- **비회원**: 모든 기업에 대해 `isSubscribed: false` 반환
- **회원**: 실제 구독 여부에 따라 `true/false` 반환

### 영향받는 API

- `GET /v1/companies` - 기업 필터링 및 검색
- `GET /v1/companies/{companyId}` - 기업 상세 조회
- `GET /v1/companies/subscriptions` - 구독한 회사 조회

swagger 테스트 성공 결과 스크린샷 첨부
<br>

## 연결된 issue

close #66
<br>

## Approve 하기 전 확인해주세요!

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 회사 목록/상세/유사 회사에 ‘구독됨’ 표시가 추가되어 로그인 시 내 구독 상태가 즉시 반영됩니다.
  - 내 구독 회사 소식 목록을 사용자 컨텍스트로 제공하며 경로가 더 직관적으로 단순화되었습니다.
  - 구독/구독 해제가 더 간단한 흐름으로 개선되었습니다.

- 리팩터링
  - 응답 형식을 통일해 일관된 성공 응답을 제공합니다.

- 문서
  - 관련 엔드포인트에 설명이 추가되어 API 문서 가독성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->