### PR TITLE
REFACTOR: 파라미터 받는 방식을 변경한다

### DIFF
--- a/src/main/java/com/project/zighang/domain/subscription/controller/SubscriptionController.java
+++ b/src/main/java/com/project/zighang/domain/subscription/controller/SubscriptionController.java
@@ -22,8 +22,8 @@ public class SubscriptionController {
 
     private final SubscriptionService subscriptionService;
 
-    @PostMapping
-    public RspTemplate<List<SubscriptionResponse>> register(@RequestParam Long companyId,
+    @PostMapping("/{companyId}")
+    public RspTemplate<List<SubscriptionResponse>> register(@PathVariable Long companyId,
                                                             @AuthenticationPrincipal UserDetailsImpl userDetails) {
         List<UserCompanySubscription> subscriptions = subscriptionService.register(userDetails.getId(), companyId);
 
@@ -34,8 +34,8 @@ public class SubscriptionController {
         return RspTemplate.success(Success.SUBSCRIBE_SUCCESS, subscriptionResponse);
     }
 
-    @DeleteMapping
-    public RspTemplate<List<SubscriptionResponse>> unregister(@RequestParam Long companyId,
+    @DeleteMapping("/{companyId}")
+    public RspTemplate<List<SubscriptionResponse>> unregister(@PathVariable Long companyId,
                                                               @AuthenticationPrincipal UserDetailsImpl userDetails) {
         List<UserCompanySubscription> subscriptions = subscriptionService.unregister(userDetails.getId(), companyId);
 


### PR DESCRIPTION
# 지금 브랜치에서 작업한 내용 

## 기능 설명

구독 관련 API 파라미터 리팩토링 작업을 완료했습니다.
- 구독 등록 API (`POST /v1/subscriptions/{companyId}`)
- 구독 해제 API (`DELETE /v1/subscriptions/{companyId}`)

swagger 테스트 성공 결과 스크린샷 첨부
<br>

## 연결된 issue

close #69
<br>

## Approve 하기 전 확인해주세요!

- [ ] 구독 API 파라미터 리팩토링이 의도대로 잘 이루어졌는지 확인 부탁드립니다.
- [ ] 응답 형식(SubscriptionResponse)이 적절한지 검토해주세요.

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - 구독 등록/해지 API에서 회사 ID 전달 방식을 쿼리 파라미터에서 경로 변수로 변경했습니다. 이제 요청 경로에 /{companyId}를 포함해 호출하세요(POST 및 DELETE 모두 적용).
  - 응답 형식과 인증 요구사항은 동일합니다.
  - 기존 쿼리 파라미터 기반 호출은 더 이상 지원되지 않을 수 있으므로, 클라이언트 요청을 경로 기반으로 업데이트해 주세요.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->