### PR TITLE
[FIX] 뉴스레터 기업 구독에서 userDetails null error 대응

### DIFF
--- a/src/main/java/com/project/zighang/oauth2/service/JwtAuthenticationFilter.java
+++ b/src/main/java/com/project/zighang/oauth2/service/JwtAuthenticationFilter.java
@@ -31,20 +31,34 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private String resolveToken(HttpServletRequest request) {
-        String bearerToken = request.getHeader("Authorization");
-        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
-            return bearerToken.substring(7);
+        String cookieToken = resolveTokenFromCookie(request);
+        if (StringUtils.hasText(cookieToken)) {
+            return cookieToken;
         }
 
+        return resolveTokenFromHeader(request);
+    }
+
+    private String resolveTokenFromCookie(HttpServletRequest request) {
         Cookie[] cookies = request.getCookies();
         if (cookies != null) {
             for (Cookie cookie : cookies) {
                 if ("accessToken".equals(cookie.getName())) {
-                    return cookie.getValue();
+                    String token = cookie.getValue();
+                    if (StringUtils.hasText(token)) {
+                        return token;
+                    }
                 }
             }
         }
+        return null;
+    }
 
+    private String resolveTokenFromHeader(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
         return null;
     }
 }

--- a/src/main/java/com/project/zighang/oauth2/service/TokenProvider.java
+++ b/src/main/java/com/project/zighang/oauth2/service/TokenProvider.java
@@ -9,15 +9,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 import java.security.Key;
-import java.util.Collections;
 import java.util.Date;
-import java.util.List;
 
 @Slf4j
 @Component
@@ -54,6 +50,8 @@ public class TokenProvider {
 
         // refreshToken에 대한 로직은 미구현 계획입니다.
         String refreshToken = Jwts.builder()
+                .setSubject(user.getId().toString())
+                .setIssuedAt(new Date(nowTime))
                 .setExpiration(refreshExpiredTime)
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();


### PR DESCRIPTION
## 기능 설명
- 뉴스레터 기업 구독에서 userDetails null error 대응

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 브라우저 쿠키(accessToken)에서 토큰을 우선 인식하고, 없을 경우 Authorization 헤더로 대체 인증합니다. 헤더 없이도 자동 로그인 유지가 가능해져 새로고침·다중 탭 사용 시 사용성이 향상됩니다.
- 버그 수정
  - 토큰 메타데이터 정비로 리프레시 흐름의 일관성이 개선되어 드물게 발생하던 재인증 이슈가 감소했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->