### PR TITLE
[Fix] 오늘의 지원 1차 QA 수정사항 반영

### DIFF
--- a/src/main/java/com/project/zighang/domain/post/controller/PostController.java
+++ b/src/main/java/com/project/zighang/domain/post/controller/PostController.java
@@ -93,6 +93,17 @@ public class PostController {
         return RspTemplate.success(Success.GET_API_REQUEST_SUCCESS, applyCountDto);
     }
 
+    @PutMapping("/apply-status")
+    @Operation(summary = "지난 지원 합격여부 수정", description = "지원한 공고의 합격여부는 (대기중, 합격, 불합격)으로 나뉩니다.")
+    public RspTemplate<?> updateApplyStatus(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestBody PutPostApplyStatusDto request
+    ) {
+        UserEntity loginUser = getUserEntityFromUserDetailsImpl(userDetails);
+        postService.updateApplyStatus(request, loginUser);
+        return RspTemplate.success(Success.PUT_APPLY_STATUS);
+    }
+
     private UserEntity getUserEntityFromUserDetailsImpl(UserDetailsImpl userDetails) throws RuntimeException {
         if (userDetails == null) {
             throw new NotFoundException(com.project.zighang.global.exception.Error.NOT_FOUND_USER, Error.NOT_FOUND_USER.getMessage());

--- a/src/main/java/com/project/zighang/domain/post/controller/PostController.java
+++ b/src/main/java/com/project/zighang/domain/post/controller/PostController.java
@@ -74,6 +74,15 @@ public class PostController {
         return RspTemplate.success(Success.GET_API_REQUEST_SUCCESS, userApplyHistory);
     }
 
+    @PostMapping("/resume")
+    @Operation(summary = "공고에 지원 할 때 제출한 이력서 파일 저장")
+    public RspTemplate<?> postResumeFile(
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        UserEntity loginUser = getUserEntityFromUserDetailsImpl(userDetails);
+
+    }
+
     private UserEntity getUserEntityFromUserDetailsImpl(UserDetailsImpl userDetails) throws RuntimeException {
         if (userDetails == null) {
             throw new NotFoundException(com.project.zighang.global.exception.Error.NOT_FOUND_USER, Error.NOT_FOUND_USER.getMessage());

--- a/src/main/java/com/project/zighang/domain/post/controller/PostController.java
+++ b/src/main/java/com/project/zighang/domain/post/controller/PostController.java
@@ -1,5 +1,6 @@
 package com.project.zighang.domain.post.controller;
 
+import com.project.zighang.domain.post.dto.ApplyCountDto;
 import com.project.zighang.global.exception.Error;
 import com.project.zighang.global.exception.Success;
 import com.project.zighang.global.exception.model.NotFoundException;
@@ -74,13 +75,14 @@ public class PostController {
         return RspTemplate.success(Success.GET_API_REQUEST_SUCCESS, userApplyHistory);
     }
 
-    @PostMapping("/resume")
-    @Operation(summary = "공고에 지원 할 때 제출한 이력서 파일 저장")
-    public RspTemplate<?> postResumeFile(
+    @Operation(summary = "지원 개수 현황 확인" , description = "오늘 지원한 곳 개수, 이번 주 지원 개수, 누적 지원 개수를 반환합니다.")
+    @GetMapping(value = "/apply")
+    public RspTemplate<?> getApplyCount(
             @AuthenticationPrincipal UserDetailsImpl userDetails
     ) {
         UserEntity loginUser = getUserEntityFromUserDetailsImpl(userDetails);
-
+        ApplyCountDto applyCountDto = postService.getUserApplyCount(loginUser);
+        return RspTemplate.success(Success.GET_API_REQUEST_SUCCESS, applyCountDto);
     }
 
     private UserEntity getUserEntityFromUserDetailsImpl(UserDetailsImpl userDetails) throws RuntimeException {

--- a/src/main/java/com/project/zighang/domain/post/controller/PostController.java
+++ b/src/main/java/com/project/zighang/domain/post/controller/PostController.java
@@ -94,7 +94,20 @@ public class PostController {
     }
 
     @PutMapping("/apply-status")
-    @Operation(summary = "지난 지원 합격여부 수정", description = "지원한 공고의 합격여부는 (대기중, 합격, 불합격)으로 나뉩니다.")
+    @Operation(
+            summary = "지원 상태 변경",
+            description = """
+        지원한 공고의 합격 여부를 변경합니다.
+        
+        **recruitmentId**
+        - 해당 공고의 recruitmentId
+        
+        **statusCode:**
+        - pending: 대기중 (심사 중)
+        - passed: 합격
+        - rejected: 불합격 (탈락)
+        """
+    )
     public RspTemplate<?> updateApplyStatus(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @RequestBody PutPostApplyStatusDto request

--- a/src/main/java/com/project/zighang/domain/post/controller/PostController.java
+++ b/src/main/java/com/project/zighang/domain/post/controller/PostController.java
@@ -1,13 +1,10 @@
 package com.project.zighang.domain.post.controller;
 
-import com.project.zighang.domain.post.dto.ApplyCountDto;
+import com.project.zighang.domain.post.dto.*;
 import com.project.zighang.global.exception.Error;
 import com.project.zighang.global.exception.Success;
 import com.project.zighang.global.exception.model.NotFoundException;
 import com.project.zighang.global.exception.template.RspTemplate;
-import com.project.zighang.domain.post.dto.PageDto;
-import com.project.zighang.domain.post.dto.PostApplyJobDto;
-import com.project.zighang.domain.post.dto.PostResponseDto;
 import com.project.zighang.domain.post.service.PostService;
 import com.project.zighang.domain.user.entity.UserEntity;
 import com.project.zighang.domain.user.entity.UserDetailsImpl;
@@ -55,7 +52,7 @@ public class PostController {
     }
 
     @PostMapping("/apply")
-    @Operation(summary = "공고 지원", description = "이미 지원한 공고는 다시 지원할 수 없습니다.")
+    @Operation(summary = "공고 지원 추가", description = "이미 지원한 공고는 다시 지원할 수 없습니다.")
     public RspTemplate<?> applyInJobPost(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @RequestBody PostApplyJobDto request
@@ -63,6 +60,17 @@ public class PostController {
         UserEntity loginUser = getUserEntityFromUserDetailsImpl(userDetails);
         postService.applyJobPost(request, loginUser);
         return RspTemplate.success(Success.POST_JOB_APPLY);
+    }
+
+    @DeleteMapping("/apply")
+    @Operation(summary = "공고 지원 삭제", description = "지원한 공고를 취소합니다.")
+    public RspTemplate<?> deleteJobApply(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestBody DeleteApplyJobDto request
+            ) {
+        UserEntity loginUser = getUserEntityFromUserDetailsImpl(userDetails);
+        postService.deleteApplyPost(request, loginUser);
+        return RspTemplate.success(Success.DELETE_JOB_APPLY);
     }
 
     @GetMapping("/apply-history")

--- a/src/main/java/com/project/zighang/domain/post/controller/PostController.java
+++ b/src/main/java/com/project/zighang/domain/post/controller/PostController.java
@@ -79,7 +79,7 @@ public class PostController {
             @AuthenticationPrincipal UserDetailsImpl userDetails
     ) {
         UserEntity loginUser = getUserEntityFromUserDetailsImpl(userDetails);
-        List<PostResponseDto> userApplyHistory = postService.getAllUserApplyHistory(loginUser);
+        List<ApplyPostResponseDto> userApplyHistory = postService.getAllUserApplyHistory(loginUser);
         return RspTemplate.success(Success.GET_API_REQUEST_SUCCESS, userApplyHistory);
     }
 

--- a/src/main/java/com/project/zighang/domain/post/dto/ApplyCountDto.java
+++ b/src/main/java/com/project/zighang/domain/post/dto/ApplyCountDto.java
@@ -1,0 +1,8 @@
+package com.project.zighang.domain.post.dto;
+
+public record ApplyCountDto(
+        Integer todayApplyCount,
+        Integer thisWeekApplyCount,
+        Integer totalApplyCount
+) {
+}

--- a/src/main/java/com/project/zighang/domain/post/dto/ApplyPostResponseDto.java
+++ b/src/main/java/com/project/zighang/domain/post/dto/ApplyPostResponseDto.java
@@ -1,0 +1,60 @@
+package com.project.zighang.domain.post.dto;
+
+import com.project.zighang.domain.post.entity.PostApplyEntity;
+import com.project.zighang.domain.post.entity.PostEntity;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public record ApplyPostResponseDto(
+        Long recruitmentId,
+        String companyName,
+        String recruitmentOriginUrl,
+        List<String> depthTwo,
+        String applyStatus
+) {
+    public static ApplyPostResponseDto from(PostApplyEntity entity) {
+        PostEntity postEntity = entity.getPostEntity();
+        String applyStatus = "대기중";
+
+        if (entity.getApplyStatus() != null && entity.getApplyStatus().getDescription() != null) {
+            applyStatus = entity.getApplyStatus().getDescription();
+        }
+
+        return new ApplyPostResponseDto(
+                postEntity.getRecruitmentId(),
+                filterValueInSummaryColumn("회사 명", postEntity.getSummaryData()),
+                filterValueInSummaryColumn("직무 명", postEntity.getSummaryData()),
+                cleanRawDepthTwoString(postEntity.getDepthTwo()),
+                applyStatus
+        );
+    }
+
+    private static List<String> cleanRawDepthTwoString(String data) {
+        if (data == null || data.trim().isEmpty()) {
+            return Collections.emptyList();
+        }
+        return Arrays.stream(data.split(","))
+                .map(s -> s.trim().replace("'", ""))
+                .collect(Collectors.toList());
+    }
+
+    private static String filterValueInSummaryColumn(String value, String summary) {
+        if (summary == null || summary.isBlank()) {
+            return null;
+        }
+
+        Pattern pattern = Pattern.compile("\\*\\*" + Pattern.quote(value) + "\\*\\*\\s*:\\s*(.*)");
+        Matcher matcher = pattern.matcher(summary);
+
+        if (matcher.find()) {
+            return matcher.group(1).trim();
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/project/zighang/domain/post/dto/DeleteApplyJobDto.java
+++ b/src/main/java/com/project/zighang/domain/post/dto/DeleteApplyJobDto.java
@@ -1,0 +1,8 @@
+package com.project.zighang.domain.post.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record DeleteApplyJobDto(
+        @NotNull Long recruitmentId
+) {
+}

--- a/src/main/java/com/project/zighang/domain/post/dto/PostResumeRequestDto.java
+++ b/src/main/java/com/project/zighang/domain/post/dto/PostResumeRequestDto.java
@@ -1,0 +1,6 @@
+package com.project.zighang.domain.post.dto;
+
+public record PostResumeRequestDto(
+        String prefix, String fileName
+) {
+}

--- a/src/main/java/com/project/zighang/domain/post/dto/PutPostApplyStatusDto.java
+++ b/src/main/java/com/project/zighang/domain/post/dto/PutPostApplyStatusDto.java
@@ -1,0 +1,12 @@
+package com.project.zighang.domain.post.dto;
+
+import com.project.zighang.domain.post.enumerate.ApplyStatus;
+
+public record PutPostApplyStatusDto(
+        Long recruitmentId,
+        String statusCode
+) {
+    public ApplyStatus getApplyStatus() {
+        return ApplyStatus.fromCode(statusCode);
+    }
+}

--- a/src/main/java/com/project/zighang/domain/post/dto/PutPostApplyStatusDto.java
+++ b/src/main/java/com/project/zighang/domain/post/dto/PutPostApplyStatusDto.java
@@ -1,12 +1,18 @@
 package com.project.zighang.domain.post.dto;
 
-import com.project.zighang.domain.post.enumerate.ApplyStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public record PutPostApplyStatusDto(
+        @Schema(description = "공고 ID", example = "1")
+        @NotNull(message = "공고 ID는 필수입니다")
         Long recruitmentId,
+
+        @Schema(description = "지원 상태 코드",
+                allowableValues = {"pending", "passed", "rejected"},
+                example = "pending")
+        @NotBlank(message = "상태 코드는 필수입니다")
         String statusCode
 ) {
-    public ApplyStatus getApplyStatus() {
-        return ApplyStatus.fromCode(statusCode);
-    }
 }

--- a/src/main/java/com/project/zighang/domain/post/dto/ResumeResponse.java
+++ b/src/main/java/com/project/zighang/domain/post/dto/ResumeResponse.java
@@ -1,0 +1,8 @@
+package com.project.zighang.domain.post.dto;
+
+import com.project.zighang.global.client.objectStorage.dto.PreSignedUrlResponse;
+
+public record ResumeResponse(
+        PreSignedUrlResponse preSignedUrlResponse
+) {
+}

--- a/src/main/java/com/project/zighang/domain/post/entity/ApplicationEntity.java
+++ b/src/main/java/com/project/zighang/domain/post/entity/ApplicationEntity.java
@@ -1,0 +1,30 @@
+package com.project.zighang.domain.post.entity;
+
+import com.project.zighang.domain.user.entity.UserEntity;
+import com.project.zighang.global.common.BaseEntity;
+import jakarta.persistence.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+public class ApplicationEntity extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recruitment_id", nullable = false)
+    private PostEntity jobPosting;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_entity_id", nullable = false)
+    private UserEntity user;
+
+    @OneToMany(
+            mappedBy = "application",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true,
+            fetch = FetchType.LAZY
+    )
+    private List<ResumeFileEntity> files = new ArrayList<>();
+
+
+}

--- a/src/main/java/com/project/zighang/domain/post/entity/PostApplyEntity.java
+++ b/src/main/java/com/project/zighang/domain/post/entity/PostApplyEntity.java
@@ -27,6 +27,7 @@ public class PostApplyEntity extends BaseEntity {
     @JoinColumn(name = "recruitment_id")
     private PostEntity postEntity;
 
+    @Setter
     @Enumerated(EnumType.STRING)
     @Column(length = 50)
     private ApplyStatus applyStatus = ApplyStatus.PENDING;

--- a/src/main/java/com/project/zighang/domain/post/entity/ResumeFileEntity.java
+++ b/src/main/java/com/project/zighang/domain/post/entity/ResumeFileEntity.java
@@ -1,0 +1,18 @@
+package com.project.zighang.domain.post.entity;
+
+import com.project.zighang.global.common.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class ResumeFileEntity extends BaseEntity {
+
+    private String originalFileName;
+    private String objectUrl;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "application_entity_id")
+    private ApplicationEntity application;
+}

--- a/src/main/java/com/project/zighang/domain/post/enumerate/ApplyStatus.java
+++ b/src/main/java/com/project/zighang/domain/post/enumerate/ApplyStatus.java
@@ -9,7 +9,7 @@ import java.util.Arrays;
 @RequiredArgsConstructor
 public enum ApplyStatus {
     PASSED("passed", "합격"),
-    PENDING("pending", "심사중"),
+    PENDING("pending", "대기중"),
     REJECTED("rejected", "탈락");
 
     private final String code;
@@ -19,9 +19,7 @@ public enum ApplyStatus {
         return Arrays.stream(values())
                 .filter(status -> status.code.equalsIgnoreCase(code))
                 .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException(
-                        String.format("Invalid status code: %s. Valid codes: %s",
-                                code, Arrays.toString(getAllCodes()))));
+                .orElseThrow(IllegalArgumentException::new);
     }
 
     private static String[] getAllCodes() {

--- a/src/main/java/com/project/zighang/domain/post/enumerate/ApplyStatus.java
+++ b/src/main/java/com/project/zighang/domain/post/enumerate/ApplyStatus.java
@@ -3,13 +3,31 @@ package com.project.zighang.domain.post.enumerate;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Arrays;
+
 @Getter
 @RequiredArgsConstructor
 public enum ApplyStatus {
-    PASSED("합격"),
-    PENDING("심사중"),
-    REJECTED("탈락");
+    PASSED("passed", "합격"),
+    PENDING("pending", "심사중"),
+    REJECTED("rejected", "탈락");
 
+    private final String code;
     private final String description;
+
+    public static ApplyStatus fromCode(String code) {
+        return Arrays.stream(values())
+                .filter(status -> status.code.equalsIgnoreCase(code))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(
+                        String.format("Invalid status code: %s. Valid codes: %s",
+                                code, Arrays.toString(getAllCodes()))));
+    }
+
+    private static String[] getAllCodes() {
+        return Arrays.stream(values())
+                .map(ApplyStatus::getCode)
+                .toArray(String[]::new);
+    }
 }
 

--- a/src/main/java/com/project/zighang/domain/post/repository/PostApplyEntityRepository.java
+++ b/src/main/java/com/project/zighang/domain/post/repository/PostApplyEntityRepository.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface PostApplyEntityRepository extends JpaRepository<PostApplyEntity, Long> {
@@ -43,4 +44,6 @@ public interface PostApplyEntityRepository extends JpaRepository<PostApplyEntity
                                   @Param("endOfWeek") LocalDateTime endOfWeek);
 
     Integer countByUserEntityId(Long userId);
+
+    Optional<PostApplyEntity> findPostApplyEntityByPostEntityAndUserEntity(PostEntity postEntity, UserEntity userEntity);
 }

--- a/src/main/java/com/project/zighang/domain/post/repository/PostApplyEntityRepository.java
+++ b/src/main/java/com/project/zighang/domain/post/repository/PostApplyEntityRepository.java
@@ -25,4 +25,22 @@ public interface PostApplyEntityRepository extends JpaRepository<PostApplyEntity
 
     @Query("SELECT pa FROM PostApplyEntity pa JOIN FETCH pa.postEntity WHERE pa.userEntity = :user AND pa.applyStatus = :status AND pa.createdAt BETWEEN :startDate AND :endDate")
     List<PostApplyEntity> findAllByUserEntityAndApplyStatusAndCreatedAtBetweenWithPostFetch(@Param("user") UserEntity user, @Param("status") ApplyStatus status, @Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
+
+    @Query("SELECT COUNT(pa) FROM PostApplyEntity pa " +
+            "WHERE pa.userEntity.id = :userId " +
+            "AND pa.createdAt >= :startOfDay " +
+            "AND pa.createdAt < :endOfDay")
+    Integer getTodayApplyCount(@Param("userId") Long userId,
+                               @Param("startOfDay") LocalDateTime startOfDay,
+                               @Param("endOfDay") LocalDateTime endOfDay);
+
+    @Query("SELECT COUNT(pa) FROM PostApplyEntity pa " +
+            "WHERE pa.userEntity.id = :userId " +
+            "AND pa.createdAt >= :startOfWeek " +
+            "AND pa.createdAt < :endOfWeek")
+    Integer getThisWeekApplyCount(@Param("userId") Long userId,
+                                  @Param("startOfWeek") LocalDateTime startOfWeek,
+                                  @Param("endOfWeek") LocalDateTime endOfWeek);
+
+    Integer countByUserEntityId(Long userId);
 }

--- a/src/main/java/com/project/zighang/domain/post/service/PostService.java
+++ b/src/main/java/com/project/zighang/domain/post/service/PostService.java
@@ -11,7 +11,7 @@ public interface PostService {
 
     List<PostResponseDto> getTodayApplyPostList(UserEntity loginUser);
 
-    List<PostResponseDto> getAllUserApplyHistory(UserEntity loginUser);
+    List<ApplyPostResponseDto> getAllUserApplyHistory(UserEntity loginUser);
 
     void applyJobPost(PostApplyJobDto request, UserEntity loginUser);
 

--- a/src/main/java/com/project/zighang/domain/post/service/PostService.java
+++ b/src/main/java/com/project/zighang/domain/post/service/PostService.java
@@ -4,6 +4,7 @@ import com.project.zighang.domain.post.dto.PostApplyJobDto;
 import com.project.zighang.domain.post.dto.PostResponseDto;
 import com.project.zighang.domain.post.dto.PostResumeRequestDto;
 import com.project.zighang.domain.post.dto.ResumeResponse;
+import com.project.zighang.domain.post.dto.ApplyCountDto;
 import com.project.zighang.domain.user.entity.UserEntity;
 import org.springframework.data.domain.Page;
 
@@ -19,4 +20,6 @@ public interface PostService {
     void applyJobPost(PostApplyJobDto request, UserEntity loginUser);
 
     ResumeResponse postResumeFile(PostResumeRequestDto request, UserEntity loginUser);
+
+    ApplyCountDto getUserApplyCount(UserEntity loginUser);
 }

--- a/src/main/java/com/project/zighang/domain/post/service/PostService.java
+++ b/src/main/java/com/project/zighang/domain/post/service/PostService.java
@@ -2,6 +2,8 @@ package com.project.zighang.domain.post.service;
 
 import com.project.zighang.domain.post.dto.PostApplyJobDto;
 import com.project.zighang.domain.post.dto.PostResponseDto;
+import com.project.zighang.domain.post.dto.PostResumeRequestDto;
+import com.project.zighang.domain.post.dto.ResumeResponse;
 import com.project.zighang.domain.user.entity.UserEntity;
 import org.springframework.data.domain.Page;
 
@@ -15,4 +17,6 @@ public interface PostService {
     List<PostResponseDto> getAllUserApplyHistory(UserEntity loginUser);
 
     void applyJobPost(PostApplyJobDto request, UserEntity loginUser);
+
+    ResumeResponse postResumeFile(PostResumeRequestDto request, UserEntity loginUser);
 }

--- a/src/main/java/com/project/zighang/domain/post/service/PostService.java
+++ b/src/main/java/com/project/zighang/domain/post/service/PostService.java
@@ -1,6 +1,7 @@
 package com.project.zighang.domain.post.service;
 
 import com.project.zighang.domain.post.dto.*;
+import com.project.zighang.domain.post.enumerate.ApplyStatus;
 import com.project.zighang.domain.user.entity.UserEntity;
 import org.springframework.data.domain.Page;
 
@@ -20,4 +21,6 @@ public interface PostService {
     ApplyCountDto getUserApplyCount(UserEntity loginUser);
 
     void deleteApplyPost(DeleteApplyJobDto request, UserEntity loginUser);
+
+    void updateApplyStatus(PutPostApplyStatusDto request, UserEntity loginUser);
 }

--- a/src/main/java/com/project/zighang/domain/post/service/PostService.java
+++ b/src/main/java/com/project/zighang/domain/post/service/PostService.java
@@ -1,10 +1,6 @@
 package com.project.zighang.domain.post.service;
 
-import com.project.zighang.domain.post.dto.PostApplyJobDto;
-import com.project.zighang.domain.post.dto.PostResponseDto;
-import com.project.zighang.domain.post.dto.PostResumeRequestDto;
-import com.project.zighang.domain.post.dto.ResumeResponse;
-import com.project.zighang.domain.post.dto.ApplyCountDto;
+import com.project.zighang.domain.post.dto.*;
 import com.project.zighang.domain.user.entity.UserEntity;
 import org.springframework.data.domain.Page;
 
@@ -22,4 +18,6 @@ public interface PostService {
     ResumeResponse postResumeFile(PostResumeRequestDto request, UserEntity loginUser);
 
     ApplyCountDto getUserApplyCount(UserEntity loginUser);
+
+    void deleteApplyPost(DeleteApplyJobDto request, UserEntity loginUser);
 }

--- a/src/main/java/com/project/zighang/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/project/zighang/domain/post/service/PostServiceImpl.java
@@ -115,12 +115,7 @@ public class PostServiceImpl implements PostService {
 
     @Override
     public void updateApplyStatus(PutPostApplyStatusDto request, UserEntity loginUser) {
-        ApplyStatus newStatus;
-        try {
-            newStatus = request.getApplyStatus();
-        } catch (IllegalArgumentException e) {
-            throw new BadRequestException(Error.BAD_REQUEST_APPLY_STATUS, Error.BAD_REQUEST_APPLY_STATUS.getMessage());
-        }
+        ApplyStatus newStatus = convertToApplyStatus(request.statusCode());
 
         Long recruitmentId = request.recruitmentId();
         PostEntity postEntity = postEntityRepository.findById(recruitmentId).orElseThrow(
@@ -132,6 +127,14 @@ public class PostServiceImpl implements PostService {
                 .orElseThrow(() -> new NotFoundException(Error.NOT_FOUND_APPLY, Error.NOT_FOUND_APPLY.getMessage()));
 
         applyEntity.setApplyStatus(newStatus);
+    }
+
+    private ApplyStatus convertToApplyStatus(String statusCode) {
+        try {
+            return ApplyStatus.fromCode(statusCode);
+        } catch (IllegalArgumentException e) {
+            throw new BadRequestException(Error.BAD_REQUEST_APPLY_STATUS, Error.BAD_REQUEST_APPLY_STATUS.getMessage());
+        }
     }
 
     @Override

--- a/src/main/java/com/project/zighang/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/project/zighang/domain/post/service/PostServiceImpl.java
@@ -1,5 +1,9 @@
 package com.project.zighang.domain.post.service;
 
+import com.project.zighang.domain.post.dto.PostResumeRequestDto;
+import com.project.zighang.domain.post.dto.ResumeResponse;
+import com.project.zighang.global.client.objectStorage.dto.PreSignedUrlResponse;
+import com.project.zighang.global.client.objectStorage.service.NcpPresignedUrlReader;
 import com.project.zighang.global.exception.Error;
 import com.project.zighang.global.exception.model.BadRequestException;
 import com.project.zighang.global.exception.model.NotFoundException;
@@ -30,6 +34,8 @@ public class PostServiceImpl implements PostService {
     private final PostEntityRepository postEntityRepository;
     private final UserOnboardingRepository userOnboardingRepository;
     private final PostApplyEntityRepository postApplyEntityRepository;
+
+    private final NcpPresignedUrlReader presignedUrlReader;
 
     private static final int MAX_SIZE = 50;
 
@@ -80,6 +86,16 @@ public class PostServiceImpl implements PostService {
         }
 
         postApplyEntityRepository.save(PostApplyEntity.create(loginUser, postEntity));
+    }
+
+    @Override
+    public ResumeResponse postResumeFile(PostResumeRequestDto request, UserEntity loginUser) {
+        String prefix = request.prefix();
+        String fileName = request.fileName();
+
+        PreSignedUrlResponse preSignedUrlResponse = presignedUrlReader.getPreSignedUrl(prefix, fileName);
+
+        return null;
     }
 
     private Page<PostEntity> findPostsByViewCount(Pageable pageable) {

--- a/src/main/java/com/project/zighang/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/project/zighang/domain/post/service/PostServiceImpl.java
@@ -2,6 +2,7 @@ package com.project.zighang.domain.post.service;
 
 import com.project.zighang.domain.post.dto.PostResumeRequestDto;
 import com.project.zighang.domain.post.dto.ResumeResponse;
+import com.project.zighang.domain.post.dto.ApplyCountDto;
 import com.project.zighang.global.client.objectStorage.dto.PreSignedUrlResponse;
 import com.project.zighang.global.client.objectStorage.service.NcpPresignedUrlReader;
 import com.project.zighang.global.exception.Error;
@@ -24,6 +25,9 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -95,7 +99,47 @@ public class PostServiceImpl implements PostService {
 
         PreSignedUrlResponse preSignedUrlResponse = presignedUrlReader.getPreSignedUrl(prefix, fileName);
 
+        // need to work
+
         return null;
+    }
+
+    @Override
+    public ApplyCountDto getUserApplyCount(UserEntity loginUser) {
+        Long userId = loginUser.getId();
+        return new ApplyCountDto(
+                getTodayApplyCount(userId),
+                getThisWeekApplyCount(userId),
+                getTotalApplyCount(userId)
+        );
+    }
+
+    private Integer getTotalApplyCount(Long userId) {
+        return postApplyEntityRepository.countByUserEntityId(userId);
+    }
+
+    private Integer getTodayApplyCount(Long userId) {
+        LocalDateTime[] todayRange = getTodayRange();
+        return postApplyEntityRepository.getTodayApplyCount(userId, todayRange[0], todayRange[1]);
+    }
+
+    private Integer getThisWeekApplyCount(Long userId) {
+        LocalDateTime[] weekRange = getThisWeekRange();
+        return postApplyEntityRepository.getThisWeekApplyCount(userId, weekRange[0], weekRange[1]);
+    }
+
+    private LocalDateTime[] getTodayRange() {
+        LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
+        LocalDateTime endOfDay = startOfDay.plusDays(1);
+        return new LocalDateTime[]{startOfDay, endOfDay};
+    }
+
+    private LocalDateTime[] getThisWeekRange() {
+        LocalDateTime startOfWeek = LocalDate.now()
+                .with(DayOfWeek.MONDAY)
+                .atStartOfDay();
+        LocalDateTime endOfWeek = startOfWeek.plusWeeks(1);
+        return new LocalDateTime[]{startOfWeek, endOfWeek};
     }
 
     private Page<PostEntity> findPostsByViewCount(Pageable pageable) {

--- a/src/main/java/com/project/zighang/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/project/zighang/domain/post/service/PostServiceImpl.java
@@ -1,6 +1,7 @@
 package com.project.zighang.domain.post.service;
 
 import com.project.zighang.domain.post.dto.*;
+import com.project.zighang.domain.post.enumerate.ApplyStatus;
 import com.project.zighang.global.client.objectStorage.dto.PreSignedUrlResponse;
 import com.project.zighang.global.client.objectStorage.service.NcpPresignedUrlReader;
 import com.project.zighang.global.exception.Error;
@@ -110,6 +111,27 @@ public class PostServiceImpl implements PostService {
                 .orElseThrow(() -> new NotFoundException(Error.NOT_FOUND_APPLY, Error.NOT_FOUND_APPLY.getMessage()));
 
         postApplyEntityRepository.delete(applyEntity);
+    }
+
+    @Override
+    public void updateApplyStatus(PutPostApplyStatusDto request, UserEntity loginUser) {
+        ApplyStatus newStatus;
+        try {
+            newStatus = request.getApplyStatus();
+        } catch (IllegalArgumentException e) {
+            throw new BadRequestException(Error.BAD_REQUEST_APPLY_STATUS, Error.BAD_REQUEST_APPLY_STATUS.getMessage());
+        }
+
+        Long recruitmentId = request.recruitmentId();
+        PostEntity postEntity = postEntityRepository.findById(recruitmentId).orElseThrow(
+                () -> new NotFoundException(Error.NOT_FOUND_POST, Error.NOT_FOUND_POST.getMessage())
+        );
+
+        PostApplyEntity applyEntity = postApplyEntityRepository
+                .findPostApplyEntityByPostEntityAndUserEntity(postEntity, loginUser)
+                .orElseThrow(() -> new NotFoundException(Error.NOT_FOUND_APPLY, Error.NOT_FOUND_APPLY.getMessage()));
+
+        applyEntity.setApplyStatus(newStatus);
     }
 
     @Override

--- a/src/main/java/com/project/zighang/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/project/zighang/domain/post/service/PostServiceImpl.java
@@ -67,11 +67,10 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public List<PostResponseDto> getAllUserApplyHistory(UserEntity loginUser) {
+    public List<ApplyPostResponseDto> getAllUserApplyHistory(UserEntity loginUser) {
         List<PostApplyEntity> postApplyEntityList = postApplyEntityRepository.findAllByUserEntityWithPostFetch(loginUser);
         return postApplyEntityList.stream()
-                .map(PostApplyEntity::getPostEntity)
-                .map(PostResponseDto::from)
+                .map(ApplyPostResponseDto::from)
                 .toList();
     }
 

--- a/src/main/java/com/project/zighang/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/project/zighang/domain/post/service/PostServiceImpl.java
@@ -1,18 +1,14 @@
 package com.project.zighang.domain.post.service;
 
-import com.project.zighang.domain.post.dto.PostResumeRequestDto;
-import com.project.zighang.domain.post.dto.ResumeResponse;
-import com.project.zighang.domain.post.dto.ApplyCountDto;
+import com.project.zighang.domain.post.dto.*;
 import com.project.zighang.global.client.objectStorage.dto.PreSignedUrlResponse;
 import com.project.zighang.global.client.objectStorage.service.NcpPresignedUrlReader;
 import com.project.zighang.global.exception.Error;
 import com.project.zighang.global.exception.model.BadRequestException;
 import com.project.zighang.global.exception.model.NotFoundException;
-import com.project.zighang.domain.post.dto.PostApplyJobDto;
 import com.project.zighang.domain.post.entity.PostApplyEntity;
 import com.project.zighang.domain.post.repository.PostApplyEntityRepository;
 import com.project.zighang.domain.post.repository.PostEntityRepository;
-import com.project.zighang.domain.post.dto.PostResponseDto;
 import com.project.zighang.domain.post.entity.PostEntity;
 import com.project.zighang.domain.user.entity.UserEntity;
 import com.project.zighang.domain.user.entity.UserOnboardingEntity;
@@ -102,6 +98,19 @@ public class PostServiceImpl implements PostService {
         // need to work
 
         return null;
+    }
+
+    public void deleteApplyPost(DeleteApplyJobDto request, UserEntity loginUser) {
+        Long recruitmentId = request.recruitmentId();
+        PostEntity postEntity = postEntityRepository.findById(recruitmentId).orElseThrow(
+                () -> new NotFoundException(Error.NOT_FOUND_POST, Error.NOT_FOUND_POST.getMessage())
+        );
+
+        PostApplyEntity applyEntity = postApplyEntityRepository
+                .findPostApplyEntityByPostEntityAndUserEntity(postEntity, loginUser)
+                .orElseThrow(() -> new NotFoundException(Error.NOT_FOUND_APPLY, Error.NOT_FOUND_APPLY.getMessage()));
+
+        postApplyEntityRepository.delete(applyEntity);
     }
 
     @Override

--- a/src/main/java/com/project/zighang/global/exception/Error.java
+++ b/src/main/java/com/project/zighang/global/exception/Error.java
@@ -17,6 +17,7 @@ public enum Error implements ApiResponseCode {
     BAD_REQUEST_CAREER_VALUE(HttpStatus.BAD_REQUEST, "잘못된 커리어 데이터입니다."),
     BAD_REQUEST_ALREADY_APPLIED(HttpStatus.BAD_REQUEST, "이미 지원한 공고입니다."),
     NO_DATA_AT_WEEKLY_REPORT(HttpStatus.BAD_REQUEST, "해당 주에 지원한 공고가 없어 주간 리포트를 생성할 수 없습니다."),
+    BAD_REQUEST_APPLY_STATUS(HttpStatus.BAD_REQUEST, "statusCode는 passed, pending, rejected으로만 설정할 수 있습니다."),
 
     /**
      * 404 NOT FOUND

--- a/src/main/java/com/project/zighang/global/exception/Error.java
+++ b/src/main/java/com/project/zighang/global/exception/Error.java
@@ -25,6 +25,7 @@ public enum Error implements ApiResponseCode {
     NOT_FOUND_USER_ONBOARDING(HttpStatus.NOT_FOUND, "존재하지 않는 사용자 온보딩 정보입니다."),
     NOT_FOUND_POST(HttpStatus.NOT_FOUND, "존재하지 않는 공고입니다."),
     NOT_FOUND_PROMPT(HttpStatus.NOT_FOUND, "태그에 해당하는 프롬프트가 존재하지 않습니다."),
+    NOT_FOUND_APPLY(HttpStatus.NOT_FOUND, "존재하지 않는 지원입니다."),
 
     /**
      * Redis Error

--- a/src/main/java/com/project/zighang/global/exception/Success.java
+++ b/src/main/java/com/project/zighang/global/exception/Success.java
@@ -16,6 +16,7 @@ public enum Success implements ApiResponseCode {
     UNSUBSCRIBE_SUCCESS(HttpStatus.OK, "정상적으로 구독이 취소됐습니다."),
     GET_SUBSCRIPTION_INFO_SUCCESS(HttpStatus.OK, "정상적으로 구독 정보를 불러왔습니다."),
     CREATE_REPORT_SUCCESS(HttpStatus.OK, "정상적으로 레포트가 생성됐습니다."),
+    DELETE_JOB_APPLY(HttpStatus.OK, "공고 지원이 정상적으로 취소되었습니다."),
 
     /**
      * 201 CREATED

--- a/src/main/java/com/project/zighang/global/exception/Success.java
+++ b/src/main/java/com/project/zighang/global/exception/Success.java
@@ -17,6 +17,7 @@ public enum Success implements ApiResponseCode {
     GET_SUBSCRIPTION_INFO_SUCCESS(HttpStatus.OK, "정상적으로 구독 정보를 불러왔습니다."),
     CREATE_REPORT_SUCCESS(HttpStatus.OK, "정상적으로 레포트가 생성됐습니다."),
     DELETE_JOB_APPLY(HttpStatus.OK, "공고 지원이 정상적으로 취소되었습니다."),
+    PUT_APPLY_STATUS(HttpStatus.OK, "공고 합격여부를 정상적으로 수정했습니다."),
 
     /**
      * 201 CREATED


### PR DESCRIPTION
## 기능 설명
- 오늘, 이번 주, 총 지원 공고 개수 조회 API 구현
- 공고 지원 취소 API 구현
- 지원한 공고 조회 API에 합격 여부 스키마 추가
- 지원한 공고를 기준으로 합격 여부 수정 API 구현

## 연결된 issue

close #76 
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 지원 취소(DELETE /api/post/apply), 지원 현황 조회(GET /api/post/apply), 지원 상태 수정(PUT /api/post/apply-status) 엔드포인트 추가
- 개선
  - 내 지원 내역 응답에 회사명, 원문 공고 URL, 세부분야 목록, 지원 상태 포함으로 정보 가독성 향상
- 문서
  - 지원 생성 API 설명 문구 명확화
- 오류/성공 메시지
  - 잘못된 지원 상태 코드, 존재하지 않는 지원에 대한 오류 메시지 추가
  - 지원 취소/상태 수정 성공 메시지 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->