### PR TITLE
FEAT: 사용자 정확도 데이터를 생성, 수정, 조회한다

### DIFF
--- a/src/main/java/com/project/zighang/domain/subscription/controller/SubscriptionController.java
+++ b/src/main/java/com/project/zighang/domain/subscription/controller/SubscriptionController.java
@@ -3,15 +3,20 @@ package com.project.zighang.domain.subscription.controller;
 import com.project.zighang.domain.subscription.dto.SubscriptionResponse;
 import com.project.zighang.domain.subscription.entity.UserCompanySubscription;
 import com.project.zighang.domain.subscription.service.SubscriptionService;
+import com.project.zighang.domain.user.entity.UserEntity;
+import com.project.zighang.global.exception.Error;
 import com.project.zighang.global.exception.Success;
+import com.project.zighang.global.exception.model.NotFoundException;
 import com.project.zighang.global.exception.template.RspTemplate;
 import com.project.zighang.domain.user.entity.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Slf4j
 @RestController
 @RequestMapping("/v1/subscriptions")
 @RequiredArgsConstructor
@@ -22,7 +27,9 @@ public class SubscriptionController {
     @PostMapping("/{companyId}")
     public RspTemplate<List<SubscriptionResponse>> register(@PathVariable Long companyId,
                                                             @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        List<UserCompanySubscription> subscriptions = subscriptionService.register(userDetails.getId(), companyId);
+
+        UserEntity loginUser = getUserEntityFromUserDetailsImpl(userDetails);
+        List<UserCompanySubscription> subscriptions = subscriptionService.register(loginUser.getId(), companyId);
 
         List<SubscriptionResponse> subscriptionResponse = subscriptions.stream()
                 .map(sub -> new SubscriptionResponse(sub.getId(), sub.getUserId(), sub.getCompanyId()))
@@ -34,12 +41,22 @@ public class SubscriptionController {
     @DeleteMapping("/{companyId}")
     public RspTemplate<List<SubscriptionResponse>> unregister(@PathVariable Long companyId,
                                                               @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        List<UserCompanySubscription> subscriptions = subscriptionService.unregister(userDetails.getId(), companyId);
+
+        UserEntity loginUser = getUserEntityFromUserDetailsImpl(userDetails);
+        List<UserCompanySubscription> subscriptions = subscriptionService.unregister(loginUser.getId(), companyId);
 
         List<SubscriptionResponse> subscriptionResponse = subscriptions.stream()
                 .map(sub -> new SubscriptionResponse(sub.getId(), sub.getUserId(), sub.getCompanyId()))
                 .toList();
 
         return RspTemplate.success(Success.UNSUBSCRIBE_SUCCESS, subscriptionResponse);
+    }
+
+    private UserEntity getUserEntityFromUserDetailsImpl(UserDetailsImpl userDetails) throws RuntimeException {
+        if (userDetails == null) {
+            log.warn("Authentication failed: UserDetailsImpl object is null.");
+            throw new NotFoundException(com.project.zighang.global.exception.Error.NOT_FOUND_USER, Error.NOT_FOUND_USER.getMessage());
+        }
+        return userDetails.getUserEntity();
     }
 }

--- a/src/main/java/com/project/zighang/domain/user/controller/UserController.java
+++ b/src/main/java/com/project/zighang/domain/user/controller/UserController.java
@@ -1,6 +1,8 @@
 package com.project.zighang.domain.user.controller;
 
+import com.project.zighang.domain.user.dto.request.AccuracyRequest;
 import com.project.zighang.domain.user.dto.request.ReportRequest;
+import com.project.zighang.domain.user.entity.Accuracy;
 import com.project.zighang.global.exception.Error;
 import com.project.zighang.global.exception.Success;
 import com.project.zighang.global.exception.model.NotFoundException;
@@ -128,5 +130,46 @@ public class UserController {
         ReportResponse.Weekly report = userService.generateWeeklyReport(user, year, month, weekOfMonth);
 
         return RspTemplate.success(Success.CREATE_REPORT_SUCCESS, report);
+    }
+
+    @GetMapping("/accuracy")
+    @Operation(summary = "사용자 정확도 데이터를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "정상적으로 정확도 결과를 불러왔습니다."),
+            @ApiResponse(responseCode = "404", description = "사용자의 정확도 높이기 데이터를 찾을 수 없습니다.")
+    })
+    public RspTemplate<AccuracyRequest.answers> getAccuracy(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        UserEntity loginUser = getUserEntityFromUserDetailsImpl(userDetails);
+
+        Accuracy accuracy = userService.getAccuracy(loginUser);
+        return RspTemplate.success(Success.ACCURACY_RESULT_QUERY_SUCCESS, AccuracyRequest.answers.from(accuracy));
+    }
+
+    @PostMapping("/accuracy")
+    @Operation(summary = "사용자 정확도 데이터를 생성합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "정상적으로 정확도 결과가 저장됐습니다."),
+            @ApiResponse(responseCode = "400", description = "이미 사용자의 데이터가 존재합니다.")
+    })
+    public RspTemplate<AccuracyRequest.answers> createAccuracy(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                          @RequestBody AccuracyRequest.answers answers) {
+        UserEntity loginUser = getUserEntityFromUserDetailsImpl(userDetails);
+
+        Accuracy accuracy = userService.createAccuracy(loginUser, answers);
+        return RspTemplate.success(Success.ACCURACY_RESULT_SAVE_SUCCESS, AccuracyRequest.answers.from(accuracy));
+    }
+
+    @PutMapping("/accuracy")
+    @Operation(summary = "사용자 정확도 데이터를 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "정상적으로 정확도 결과를 수정했습니다."),
+            @ApiResponse(responseCode = "404", description = "사요자의 정확도 높이기 데이터를 찾을 수 없습니다.")
+    })
+    public RspTemplate<AccuracyRequest.answers> updateAccuracy(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                            @RequestBody AccuracyRequest.answers answers) {
+        UserEntity loginUser = getUserEntityFromUserDetailsImpl(userDetails);
+
+        Accuracy accuracy = userService.updateAccuracy(loginUser, answers);
+        return RspTemplate.success(Success.ACCURACY_RESULT_UPDATE_SUCCESS, AccuracyRequest.answers.from(accuracy));
     }
 }

--- a/src/main/java/com/project/zighang/domain/user/dto/request/AccuracyRequest.java
+++ b/src/main/java/com/project/zighang/domain/user/dto/request/AccuracyRequest.java
@@ -1,0 +1,43 @@
+package com.project.zighang.domain.user.dto.request;
+
+import com.project.zighang.domain.user.entity.Accuracy;
+
+public record AccuracyRequest (
+) {
+    public record answers (
+            String question1,
+
+            String question2,
+
+            String question3,
+
+            String question4,
+
+            String question5,
+
+            String question6,
+
+            String question7,
+
+            String question8,
+
+            String question9,
+
+            String question10
+    ) {
+        public static AccuracyRequest.answers from(Accuracy accuracy) {
+            return new AccuracyRequest.answers(
+                    accuracy.getQuestion1(),
+                    accuracy.getQuestion2(),
+                    accuracy.getQuestion3(),
+                    accuracy.getQuestion4(),
+                    accuracy.getQuestion5(),
+                    accuracy.getQuestion6(),
+                    accuracy.getQuestion7(),
+                    accuracy.getQuestion8(),
+                    accuracy.getQuestion9(),
+                    accuracy.getQuestion10()
+            );
+        }
+    }
+}

--- a/src/main/java/com/project/zighang/domain/user/entity/Accuracy.java
+++ b/src/main/java/com/project/zighang/domain/user/entity/Accuracy.java
@@ -1,0 +1,67 @@
+package com.project.zighang.domain.user.entity;
+
+import com.project.zighang.domain.user.dto.request.AccuracyRequest;
+import com.project.zighang.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Builder
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Accuracy extends BaseEntity {
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_entity_id")
+    private UserEntity userEntity;
+
+    private String question1;
+
+    private String question2;
+
+    private String question3;
+
+    private String question4;
+
+    private String question5;
+
+    private String question6;
+
+    private String question7;
+
+    private String question8;
+
+    private String question9;
+
+    private String question10;
+
+    public static Accuracy create(UserEntity userEntity, AccuracyRequest.answers answers) {
+        return Accuracy.builder()
+                .userEntity(userEntity)
+                .question1(answers.question1())
+                .question2(answers.question2())
+                .question3(answers.question3())
+                .question4(answers.question4())
+                .question5(answers.question5())
+                .question6(answers.question6())
+                .question7(answers.question7())
+                .question8(answers.question8())
+                .question9(answers.question9())
+                .question10(answers.question10())
+                .build();
+    }
+
+    public void update(AccuracyRequest.answers answers) {
+        this.question1 = answers.question1();
+        this.question2 = answers.question2();
+        this.question3 = answers.question3();
+        this.question4 = answers.question4();
+        this.question5 = answers.question5();
+        this.question6 = answers.question6();
+        this.question7 = answers.question7();
+        this.question8 = answers.question8();
+        this.question9 = answers.question9();
+        this.question10 = answers.question10();
+    }
+}

--- a/src/main/java/com/project/zighang/domain/user/entity/UserOnboardingEntity.java
+++ b/src/main/java/com/project/zighang/domain/user/entity/UserOnboardingEntity.java
@@ -16,8 +16,7 @@ public class UserOnboardingEntity extends BaseEntity {
     @JoinColumn(name = "user_entity_id")
     private UserEntity userEntity;
 
-    // 신입 -1, 경력은 +1 +2 .. 로 받을 예정
-    private Long minCareer;
+    private Long minCareer;  // 신입 -1, 경력은 +1 +2 .. 로 받을 예정
 
     private Long maxCareer;
 

--- a/src/main/java/com/project/zighang/domain/user/repository/AccuracyRepository.java
+++ b/src/main/java/com/project/zighang/domain/user/repository/AccuracyRepository.java
@@ -1,0 +1,13 @@
+package com.project.zighang.domain.user.repository;
+
+import com.project.zighang.domain.user.entity.Accuracy;
+import com.project.zighang.domain.user.entity.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface AccuracyRepository extends JpaRepository<Accuracy, Long> {
+    Optional<Accuracy> findByUserEntity(UserEntity userEntity);
+}

--- a/src/main/java/com/project/zighang/domain/user/repository/AddressRepository.java
+++ b/src/main/java/com/project/zighang/domain/user/repository/AddressRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+
 @Repository
 public interface AddressRepository extends JpaRepository<AddressEntity, Long> {
 

--- a/src/main/java/com/project/zighang/domain/user/service/UserService.java
+++ b/src/main/java/com/project/zighang/domain/user/service/UserService.java
@@ -3,7 +3,9 @@ package com.project.zighang.domain.user.service;
 import com.project.zighang.domain.oauth2.dto.TokenDto;
 import com.project.zighang.domain.user.dto.PostUserOnboardingDto;
 import com.project.zighang.domain.user.dto.PostUserTodayApplyCountDTO;
+import com.project.zighang.domain.user.dto.request.AccuracyRequest;
 import com.project.zighang.domain.user.dto.response.ReportResponse;
+import com.project.zighang.domain.user.entity.Accuracy;
 import com.project.zighang.domain.user.entity.UserEntity;
 
 public interface UserService {
@@ -18,4 +20,10 @@ public interface UserService {
     TokenDto saveDummyUser();
 
     ReportResponse.Weekly generateWeeklyReport(UserEntity userEntity, Integer year, Integer month, Integer weekOfMonth) throws Exception;
+
+    Accuracy createAccuracy(UserEntity userEntity, AccuracyRequest.answers answers);
+
+    Accuracy updateAccuracy(UserEntity userEntity, AccuracyRequest.answers answers);
+
+    Accuracy getAccuracy(UserEntity userEntity);
 }

--- a/src/main/java/com/project/zighang/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/project/zighang/domain/user/service/UserServiceImpl.java
@@ -10,6 +10,7 @@ import com.project.zighang.domain.post.service.PostingFinder;
 import com.project.zighang.domain.user.dto.PostUserOnboardingDto;
 import com.project.zighang.domain.user.dto.PostUserTodayApplyCountDTO;
 import com.project.zighang.domain.user.dto.WeekDateInfo;
+import com.project.zighang.domain.user.dto.request.AccuracyRequest;
 import com.project.zighang.domain.user.dto.response.ReportResponse;
 import com.project.zighang.domain.user.entity.*;
 import com.project.zighang.domain.user.repository.*;
@@ -48,6 +49,7 @@ public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
     private final WeeklyReportRepository weeklyReportRepository;
     private final PostingFinder postingFinder;
+    private final AccuracyRepository accuracyRepository;
 
     @Override
     public void addUserOnboardingInfo(PostUserOnboardingDto request, UserEntity loginUser) {
@@ -218,5 +220,29 @@ public class UserServiceImpl implements UserService {
         int weekNumber = startDate.get(java.time.temporal.IsoFields.WEEK_OF_WEEK_BASED_YEAR);
 
         return new WeekDateInfo(firstDayOfMonth, startDate, endDate, weekNumber);
+    }
+
+    @Override
+    public Accuracy createAccuracy(UserEntity userEntity, AccuracyRequest.answers answers) {
+        if (accuracyRepository.findByUserEntity(userEntity).isPresent()) {
+            throw new BadRequestException(Error.ACCURACY_ALREADY_EXIST, "이미 사용자의 데이터가 존재합니다.");
+        }
+
+        Accuracy accuracy = Accuracy.create(userEntity, answers);
+        return accuracyRepository.save(accuracy);
+    }
+
+    @Override
+    public Accuracy updateAccuracy(UserEntity userEntity, AccuracyRequest.answers answers) {
+        Accuracy accuracy = accuracyRepository.findByUserEntity(userEntity)
+                .orElseThrow(() -> new NotFoundException(Error.ACCURACY_NOT_FOUND, "사요자의 정확도 높이기 데이터를 찾을 수 없습니다."));
+        accuracy.update(answers);
+        return accuracy;
+    }
+
+    @Override
+    public Accuracy getAccuracy(UserEntity userEntity){
+        return accuracyRepository.findByUserEntity(userEntity)
+                .orElseThrow(() -> new NotFoundException(Error.ACCURACY_NOT_FOUND, "사용자의 정확도 높이기 데이터를 찾을 수 없습니다."));
     }
 }

--- a/src/main/java/com/project/zighang/global/exception/Error.java
+++ b/src/main/java/com/project/zighang/global/exception/Error.java
@@ -50,7 +50,13 @@ public enum Error implements ApiResponseCode {
     /**
      * Prompt Error
      */
-    PROMPT_BUILD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "프롬프트 생성 중 오류가 발생했습니다.");
+    PROMPT_BUILD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "프롬프트 생성 중 오류가 발생했습니다."),
+
+    /**
+     * ACCURACY ERROR
+     */
+    ACCURACY_NOT_FOUND(HttpStatus.NOT_FOUND, "정확도 결과를 찾을 수 없습니다."),
+    ACCURACY_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "이미 정확도 결과가 존재합니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/project/zighang/global/exception/Success.java
+++ b/src/main/java/com/project/zighang/global/exception/Success.java
@@ -16,7 +16,8 @@ public enum Success implements ApiResponseCode {
     UNSUBSCRIBE_SUCCESS(HttpStatus.OK, "정상적으로 구독이 취소됐습니다."),
     GET_SUBSCRIPTION_INFO_SUCCESS(HttpStatus.OK, "정상적으로 구독 정보를 불러왔습니다."),
     CREATE_REPORT_SUCCESS(HttpStatus.OK, "정상적으로 레포트가 생성됐습니다."),
-
+    ACCURACY_RESULT_UPDATE_SUCCESS(HttpStatus.OK, "정상적으로 정확도 결과를 수정했습니다."),
+    ACCURACY_RESULT_QUERY_SUCCESS(HttpStatus.OK, "정상적으로 정확도 결과를 불러왔습니다."),
     /**
      * 201 CREATED
      */
@@ -24,7 +25,7 @@ public enum Success implements ApiResponseCode {
     CREATE_JWT_TOKEN_SUCCESS(HttpStatus.CREATED, "소셜 로그인 성공 및 JWT 토큰 정상 발급했습니다."),
     SUBSCRIBE_SUCCESS(HttpStatus.CREATED, "정상적으로 구독됐습니다."),
     POST_JOB_APPLY(HttpStatus.CREATED, "정상적으로 공고에 지원했습니다."),
-
+    ACCURACY_RESULT_SAVE_SUCCESS(HttpStatus.CREATED, "정상적으로 정확도 결과가 저장됐습니다."),
     POST_USER_APPLY_COUNT_API_REQUEST_SUCCESS(HttpStatus.OK, "유저 하루 추천 공고 개수가 설정되었습니다.");
 
 


### PR DESCRIPTION
## 기능 설명

사용자 정확도 관련 API 구현
- 정확도 조회(GET) API 구현
- 정확도 생성(POST) API 구현
- 정확도 수정(PUT) API 구현

swagger 테스트 성공 결과 스크린샷 첨부
<br>

## 연결된 issue
close
- #77 
<br>

## Approve 하기 전 확인해주세요!
<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 정확도 결과(총 10문항)를 조회·저장·수정하는 API 및 UI 지원을 추가했습니다. 최초 저장은 1회만 허용되며, 존재 여부에 따른 명확한 안내와 일관된 응답 상태(저장·조회·수정 성공)가 제공됩니다.
- Refactor
  - 구독 관련 요청의 인증 처리와 로깅을 강화해 인증 실패 및 오류 상황을 더 명확히 파악할 수 있도록 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->