### PR TITLE
[FIX] 오늘의 추천 공고 목록 조회 API 수정

### DIFF
--- a/src/main/java/com/project/zighang/domain/post/controller/PostController.java
+++ b/src/main/java/com/project/zighang/domain/post/controller/PostController.java
@@ -46,13 +46,17 @@ public class PostController {
         return RspTemplate.success(Success.GET_API_REQUEST_SUCCESS, PageDto.from(postPage));
     }
 
-    @GetMapping("/today-apply/recommend")
-    @Operation(summary = "오늘의 추천 공고 목록 조회", description = "선택 하기 이전에 추천하는 리스트입니다. 지원할 공고 개수보다 5개 더 보입니다.")
+    @PostMapping("/today-apply/recommend")
+    @Operation(summary = "오늘의 추천 공고 목록 조회",
+            description = "선택하기 전에 추천하는 리스트입니다. 지원할 공고 개수보다 5개 더 보입니다. " +
+                    "isFirstApiCall = true의 경우 모든 응답이 새로운 데이터로 내려갑니다. isFirstApiCall = false의 경우 requireRefreshRecruitmentId로 받은 공고 데이터만 새로운 데이터로 대체되어 내려갑니다."
+    )
     public RspTemplate<?> getTodayApplyPosts(
-            @AuthenticationPrincipal UserDetailsImpl userDetails
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestBody GetTodayApplyPostsRequest request
     ) {
         UserEntity loginUser = getUserEntityFromUserDetailsImpl(userDetails);
-        List<TodayApplyPostsResponseDto> todayApplyPosts = postService.getTodayApplyPostList(loginUser);
+        List<TodayApplyPostsResponseDto> todayApplyPosts = postService.getTodayApplyPostList(request, loginUser);
         return RspTemplate.success(Success.GET_API_REQUEST_SUCCESS, todayApplyPosts);
     }
 

--- a/src/main/java/com/project/zighang/domain/post/controller/PostController.java
+++ b/src/main/java/com/project/zighang/domain/post/controller/PostController.java
@@ -52,7 +52,7 @@ public class PostController {
             @AuthenticationPrincipal UserDetailsImpl userDetails
     ) {
         UserEntity loginUser = getUserEntityFromUserDetailsImpl(userDetails);
-        List<PostResponseDto> todayApplyPosts = postService.getTodayApplyPostList(loginUser);
+        List<TodayApplyPostsResponseDto> todayApplyPosts = postService.getTodayApplyPostList(loginUser);
         return RspTemplate.success(Success.GET_API_REQUEST_SUCCESS, todayApplyPosts);
     }
 

--- a/src/main/java/com/project/zighang/domain/post/dto/GetTodayApplyPostsRequest.java
+++ b/src/main/java/com/project/zighang/domain/post/dto/GetTodayApplyPostsRequest.java
@@ -1,0 +1,8 @@
+package com.project.zighang.domain.post.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record GetTodayApplyPostsRequest(
+        @NotNull Boolean isFirstApiCall,
+        @NotNull Long requireRefreshRecruitmentId
+) {}

--- a/src/main/java/com/project/zighang/domain/post/dto/TodayApplyPostsResponseDto.java
+++ b/src/main/java/com/project/zighang/domain/post/dto/TodayApplyPostsResponseDto.java
@@ -1,0 +1,66 @@
+package com.project.zighang.domain.post.dto;
+
+import com.project.zighang.domain.post.entity.PostEntity;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record TodayApplyPostsResponseDto(
+        Long recruitmentId,
+        Integer viewCount,
+        String title,
+        String recruitmentRegion,
+        Integer minCareer,
+        Integer maxCareer,
+        String recruitmentEndDate,
+        String companyName,
+        String workSummary,
+        String recruitmentOriginUrl,
+        List<String> depthTwo,
+        String companyLogoUrl
+) {
+    public static TodayApplyPostsResponseDto from(PostEntity entity) {
+        return new TodayApplyPostsResponseDto(
+                entity.getRecruitmentId(),
+                entity.getViewCount(),
+                entity.getTitle(),
+                entity.getRecruitmentRegion(),
+                entity.getMinCareer(),
+                entity.getMaxCareer(),
+                entity.getRecruitmentEndDate(),
+                filterValueInSummaryColumn("회사 명", entity.getSummaryData()),
+                filterValueInSummaryColumn("직무 명", entity.getSummaryData()),
+                entity.getRecruitmentOriginalUrl(),
+                cleanRawDepthTwoString(entity.getDepthTwo()),
+                null
+        );
+    }
+
+    private static List<String> cleanRawDepthTwoString(String data) {
+        if (data == null || data.trim().isEmpty()) {
+            return Collections.emptyList();
+        }
+        return Arrays.stream(data.split(","))
+                .map(s -> s.trim().replace("'", ""))
+                .collect(Collectors.toList());
+    }
+
+    private static String filterValueInSummaryColumn(String value, String summary) {
+        if (summary == null || summary.isBlank()) {
+            return null;
+        }
+
+        Pattern pattern = Pattern.compile("\\*\\*" + Pattern.quote(value) + "\\*\\*\\s*:\\s*(.*)");
+        Matcher matcher = pattern.matcher(summary);
+
+        if (matcher.find()) {
+            return matcher.group(1).trim();
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/project/zighang/domain/post/repository/PostApplyEntityRepository.java
+++ b/src/main/java/com/project/zighang/domain/post/repository/PostApplyEntityRepository.java
@@ -27,7 +27,7 @@ public interface PostApplyEntityRepository extends JpaRepository<PostApplyEntity
     @Query("SELECT pa FROM PostApplyEntity pa JOIN FETCH pa.postEntity WHERE pa.userEntity = :user AND pa.applyStatus = :status AND pa.createdAt BETWEEN :startDate AND :endDate")
     List<PostApplyEntity> findAllByUserEntityAndApplyStatusAndCreatedAtBetweenWithPostFetch(@Param("user") UserEntity user, @Param("status") ApplyStatus status, @Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
 
-    @Query("SELECT COUNT(pa) FROM PostApplyEntity pa " +
+    @Query("SELECT COALESCE(COUNT(pa), 0) FROM PostApplyEntity pa " +
             "WHERE pa.userEntity.id = :userId " +
             "AND pa.createdAt >= :startOfDay " +
             "AND pa.createdAt < :endOfDay")
@@ -35,7 +35,7 @@ public interface PostApplyEntityRepository extends JpaRepository<PostApplyEntity
                                @Param("startOfDay") LocalDateTime startOfDay,
                                @Param("endOfDay") LocalDateTime endOfDay);
 
-    @Query("SELECT COUNT(pa) FROM PostApplyEntity pa " +
+    @Query("SELECT COALESCE(COUNT(pa), 0) FROM PostApplyEntity pa " +
             "WHERE pa.userEntity.id = :userId " +
             "AND pa.createdAt >= :startOfWeek " +
             "AND pa.createdAt < :endOfWeek")
@@ -43,7 +43,8 @@ public interface PostApplyEntityRepository extends JpaRepository<PostApplyEntity
                                   @Param("startOfWeek") LocalDateTime startOfWeek,
                                   @Param("endOfWeek") LocalDateTime endOfWeek);
 
-    Integer countByUserEntityId(Long userId);
+    @Query("SELECT COUNT(p) FROM PostApplyEntity p WHERE p.userEntity.id = :userId")
+    Integer countByUserEntityIdSafe(@Param("userId") Long userId);
 
     Optional<PostApplyEntity> findPostApplyEntityByPostEntityAndUserEntity(PostEntity postEntity, UserEntity userEntity);
 }

--- a/src/main/java/com/project/zighang/domain/post/service/PostRecommendationService.java
+++ b/src/main/java/com/project/zighang/domain/post/service/PostRecommendationService.java
@@ -1,0 +1,23 @@
+package com.project.zighang.domain.post.service;
+
+import com.project.zighang.domain.post.dto.TodayApplyPostsResponseDto;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class PostRecommendationService {
+
+    private final Map<Long, List<TodayApplyPostsResponseDto>> userRecommendations = new ConcurrentHashMap<>();
+
+    public void deleteAndCreateUserRecommendations(Long userId, List<TodayApplyPostsResponseDto> request) {
+        userRecommendations.put(userId, request);
+    }
+
+    public List<TodayApplyPostsResponseDto> getRecommendations(Long userId) {
+        return userRecommendations.getOrDefault(userId, new ArrayList<>());
+    }
+}

--- a/src/main/java/com/project/zighang/domain/post/service/PostService.java
+++ b/src/main/java/com/project/zighang/domain/post/service/PostService.java
@@ -10,7 +10,7 @@ import java.util.List;
 public interface PostService {
     Page<PostResponseDto> getAllPostList(int page, int size);
 
-    List<PostResponseDto> getTodayApplyPostList(UserEntity loginUser);
+    List<TodayApplyPostsResponseDto> getTodayApplyPostList(UserEntity loginUser);
 
     List<ApplyPostResponseDto> getAllUserApplyHistory(UserEntity loginUser);
 

--- a/src/main/java/com/project/zighang/domain/post/service/PostService.java
+++ b/src/main/java/com/project/zighang/domain/post/service/PostService.java
@@ -10,7 +10,7 @@ import java.util.List;
 public interface PostService {
     Page<PostResponseDto> getAllPostList(int page, int size);
 
-    List<TodayApplyPostsResponseDto> getTodayApplyPostList(UserEntity loginUser);
+    List<TodayApplyPostsResponseDto> getTodayApplyPostList(GetTodayApplyPostsRequest request, UserEntity loginUser);
 
     List<ApplyPostResponseDto> getAllUserApplyHistory(UserEntity loginUser);
 

--- a/src/main/java/com/project/zighang/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/project/zighang/domain/post/service/PostServiceImpl.java
@@ -20,6 +20,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,6 +28,8 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -41,7 +44,12 @@ public class PostServiceImpl implements PostService {
     private final PostApplyEntityRepository postApplyEntityRepository;
     private final UserTodayPostRepository userTodayPostRepository;
 
+    private final PostRecommendationService postRecommendationService;
+
     private static final int MAX_SIZE = 50;
+    private static final int REFRESH_ID_INCREMENT = 100;
+    private static final long MAX_RECRUITMENT_ID = 12000L;
+    private static final int ROLLBACK_DECREMENT = 200;
 
     @Override
     @Transactional(readOnly = true)
@@ -53,21 +61,70 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public List<TodayApplyPostsResponseDto> getTodayApplyPostList(UserEntity loginUser) {
-        UserOnboardingEntity userOnboardingEntity = userOnboardingRepository.findByUserEntity(loginUser).orElseThrow(
-                () -> new NotFoundException(
-                        Error.NOT_FOUND_USER_ONBOARDING, Error.NOT_FOUND_USER_ONBOARDING.getMessage())
-        );
+    public List<TodayApplyPostsResponseDto> getTodayApplyPostList(GetTodayApplyPostsRequest request, UserEntity loginUser) {
+        long applyPostCount = 1;
+        if (request.isFirstApiCall()) {
+            // first time
+            UserOnboardingEntity userOnboardingEntity = userOnboardingRepository.findByUserEntity(loginUser).orElseThrow(
+                    () -> new NotFoundException(
+                            Error.NOT_FOUND_USER_ONBOARDING, Error.NOT_FOUND_USER_ONBOARDING.getMessage())
+            );
 
-        long applyPostCount = userOnboardingEntity.getDailyRecommendPostCount() + 5;
-        if (applyPostCount >= 0) {
-            return findTopNPostsByViewCount(Math.toIntExact(applyPostCount))
+            applyPostCount = userOnboardingEntity.getDailyRecommendPostCount() + 5;
+
+            // TASK - must switch findTopNPostsByViewCount to recommend module
+            List<TodayApplyPostsResponseDto> todayApplyPostsResponseDtoList = findTopNPostsByViewCount(Math.toIntExact(applyPostCount))
                     .stream()
                     .map(TodayApplyPostsResponseDto::from)
                     .toList();
+
+            postRecommendationService.deleteAndCreateUserRecommendations(loginUser.getId(), todayApplyPostsResponseDtoList);
+
+            return todayApplyPostsResponseDtoList;
+        } else {
+            // when user refresh post
+            List<TodayApplyPostsResponseDto> existingPosts = postRecommendationService.getRecommendations(loginUser.getId());
+
+            if (existingPosts.isEmpty()) {
+                log.warn("사용자 {}의 기존 메모리 데이터가 없습니다. 첫 번째 요청으로 처리", loginUser.getId());
+                return getTodayApplyPostList(new GetTodayApplyPostsRequest(true, loginUser.getId()), loginUser);
+            }
+
+            Long requiredRefreshRecruitmentId = request.requireRefreshRecruitmentId();
+            List<TodayApplyPostsResponseDto> updatedPosts = existingPosts.stream()
+                    .map(post -> {
+                        if (post.recruitmentId().equals(requiredRefreshRecruitmentId)) {
+                            return getReplacementPost(requiredRefreshRecruitmentId, post);
+                        }
+                        return post;
+                    })
+                    .toList();
+
+            postRecommendationService.deleteAndCreateUserRecommendations(loginUser.getId(), updatedPosts);
+
+            return updatedPosts;
+        }
+    }
+
+    private TodayApplyPostsResponseDto getReplacementPost(Long originalId, TodayApplyPostsResponseDto fallbackPost) {
+        Long newRecruitmentId = calculateNewRecruitmentId(originalId);
+
+        return postEntityRepository.findById(newRecruitmentId)
+                .map(TodayApplyPostsResponseDto::from)
+                .orElseGet(() -> {
+                    log.warn("대체 게시글 {}를 찾을 수 없음. 기존 게시글 유지", newRecruitmentId);
+                    return fallbackPost; // 새 게시글 없으면 기존 게시글 유지
+                });
+    }
+
+    private Long calculateNewRecruitmentId(Long originalId) {
+        long newId = originalId + REFRESH_ID_INCREMENT;
+
+        if (newId >= MAX_RECRUITMENT_ID) {
+            newId -= ROLLBACK_DECREMENT;
         }
 
-        return List.of();
+        return newId;
     }
 
     @Override
@@ -183,7 +240,7 @@ public class PostServiceImpl implements PostService {
     }
 
     private Integer getTotalApplyCount(Long userId) {
-        return postApplyEntityRepository.countByUserEntityId(userId);
+        return postApplyEntityRepository.countByUserEntityIdSafe(userId);
     }
 
     private Integer getTodayApplyCount(Long userId) {

--- a/src/main/java/com/project/zighang/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/project/zighang/domain/post/service/PostServiceImpl.java
@@ -53,7 +53,7 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public List<PostResponseDto> getTodayApplyPostList(UserEntity loginUser) {
+    public List<TodayApplyPostsResponseDto> getTodayApplyPostList(UserEntity loginUser) {
         UserOnboardingEntity userOnboardingEntity = userOnboardingRepository.findByUserEntity(loginUser).orElseThrow(
                 () -> new NotFoundException(
                         Error.NOT_FOUND_USER_ONBOARDING, Error.NOT_FOUND_USER_ONBOARDING.getMessage())
@@ -63,7 +63,7 @@ public class PostServiceImpl implements PostService {
         if (applyPostCount >= 0) {
             return findTopNPostsByViewCount(Math.toIntExact(applyPostCount))
                     .stream()
-                    .map(PostResponseDto::from)
+                    .map(TodayApplyPostsResponseDto::from)
                     .toList();
         }
 


### PR DESCRIPTION
## 기능 설명
- [Add: 오늘의 추천 공고 목록 조회 API Dto 수정](https://github.com/X-Kusitms-1/ZIGHANG_ENTERPRISE_PROJECT_BE/commit/6c90ba91305b11216c206db23daf33536c8f2db0)
- [Add: 오늘의 추천 새로고침 로직 구현](https://github.com/X-Kusitms-1/ZIGHANG_ENTERPRISE_PROJECT_BE/commit/d797fc79ae64c1c63ce8b7a7f0f5dc746b364d00)

## 연결된 issue

close #84 
<br>

## Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 오늘의 추천 지원 목록 제공 및 사용자별 추천 유지·새로고침(특정 공고 교체) 기능 추가
  - 응답에 회사명, 직무 요약, 지역, 경력, 마감일, 카테고리 등 상세 정보 포함
- 변경 사항
  - 추천 목록 조회 엔드포인트가 POST로 변경되며 요청 본문(첫 호출 여부, 교체 대상 ID) 필요
  - 응답 포맷이 새로운 추천 항목 구조로 변경됨
- 버그 수정
  - 지원 건수 집계 시 결과가 없을 경우 0으로 안전하게 반환
- 문서
  - 첫 호출/후속 호출 동작 방식에 대한 API 설명 보강

<!-- end of auto-generated comment: release notes by coderabbit.ai -->