### PR TITLE
[Fix] apply post get api에 createdAt 필드 추가

### DIFF
--- a/src/main/java/com/project/zighang/domain/post/dto/ApplyPostResponseDto.java
+++ b/src/main/java/com/project/zighang/domain/post/dto/ApplyPostResponseDto.java
@@ -3,6 +3,7 @@ package com.project.zighang.domain.post.dto;
 import com.project.zighang.domain.post.entity.PostApplyEntity;
 import com.project.zighang.domain.post.entity.PostEntity;
 
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -15,7 +16,8 @@ public record ApplyPostResponseDto(
         String companyName,
         String recruitmentOriginUrl,
         List<String> depthTwo,
-        String applyStatus
+        String applyStatus,
+        String createdAt
 ) {
     public static ApplyPostResponseDto from(PostApplyEntity entity) {
         PostEntity postEntity = entity.getPostEntity();
@@ -30,7 +32,8 @@ public record ApplyPostResponseDto(
                 filterValueInSummaryColumn("회사 명", postEntity.getSummaryData()),
                 filterValueInSummaryColumn("직무 명", postEntity.getSummaryData()),
                 cleanRawDepthTwoString(postEntity.getDepthTwo()),
-                applyStatus
+                applyStatus,
+                entity.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
         );
     }
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -19,3 +19,7 @@ login.redirect-url.frontend=test
 jwt.secret=U3ByaW5nQm9vdFRlc3RTZWNyZXRLZXlGb3JaMWdoYW5nUHJvamVjdCEyMDI0
 jwt.access-token-validity-in-milliseconds=6048000000
 jwt.refresh-token-validity-in-milliseconds=6048000000
+
+cloud.ncp.embedding.baseurl=test
+cloud.ncp.embedding.endpoint=test
+cloud.ncp.embedding.api-key=test


### PR DESCRIPTION
## 기능 설명
- [Add: createdAt 필드 추가](https://github.com/X-Kusitms-1/ZIGHANG_ENTERPRISE_PROJECT_BE/commit/107f1687df4cbc27ef967790db9427f9c7be1604)
- [Fix: test application.properties 수정](https://github.com/X-Kusitms-1/ZIGHANG_ENTERPRISE_PROJECT_BE/commit/573be1cdbf9958ef6428edf12c91912bbe67de87)

## 연결된 issue

close #94 

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 지원 공고 응답에 생성일(createdAt) 필드가 추가되어 YYYY-MM-DD 형식으로 제공됩니다. 기존 항목과 동작에는 변화가 없습니다.
- 테스트
  - 임베딩 관련 테스트 설정값(baseurl, endpoint, api-key)이 추가되었습니다. 애플리케이션 실행에는 영향이 없으며 테스트 환경 구성만 보강되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->