### PR TITLE
[FIX] 공고 조회 데이터 회사 명 결측치 데이터 필터링 처리

### DIFF
--- a/src/main/java/com/project/zighang/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/com/project/zighang/domain/post/dto/PostResponseDto.java
@@ -31,11 +31,19 @@ public record PostResponseDto(
                 entity.getMinCareer(),
                 entity.getMaxCareer(),
                 entity.getRecruitmentEndDate(),
-                filterValueInSummaryColumn("회사 명", entity.getSummaryData()),
+                getCompanyName(entity.getSummaryData()),
                 filterValueInSummaryColumn("직무 명", entity.getSummaryData()),
                 entity.getRecruitmentOriginalUrl(),
                 cleanRawDepthTwoString(entity.getDepthTwo())
         );
+    }
+
+    private static String getCompanyName(String postSummary) {
+        String companyName = filterValueInSummaryColumn("회사 명", postSummary);
+        if(companyName == null) {
+            return filterValueInSummaryColumn("회사명", postSummary);
+        }
+        return companyName;
     }
 
     private static List<String> cleanRawDepthTwoString(String data) {
@@ -52,11 +60,19 @@ public record PostResponseDto(
             return null;
         }
 
-        Pattern pattern = Pattern.compile("\\*\\*" + Pattern.quote(value) + "\\*\\*\\s*:\\s*(.*)");
-        Matcher matcher = pattern.matcher(summary);
+        String[] patterns = {
+                "\\*\\*\\s*" + Pattern.quote(value) + "\\s*\\*\\*\\s*:\\s*(.*)",
+                "\\*\\*\\s*" + Pattern.quote(value) + "\\s*:\\s*(.*)",
+                Pattern.quote(value) + "\\s*:\\s*(.*)"
+        };
 
-        if (matcher.find()) {
-            return matcher.group(1).trim();
+        for (String patternStr : patterns) {
+            Pattern pattern = Pattern.compile(patternStr, Pattern.CASE_INSENSITIVE);
+            Matcher matcher = pattern.matcher(summary);
+
+            if (matcher.find()) {
+                return matcher.group(1).trim();
+            }
         }
 
         return null;

--- a/src/main/java/com/project/zighang/domain/post/dto/TodayApplyPostsResponseDto.java
+++ b/src/main/java/com/project/zighang/domain/post/dto/TodayApplyPostsResponseDto.java
@@ -32,12 +32,20 @@ public record TodayApplyPostsResponseDto(
                 entity.getMinCareer(),
                 entity.getMaxCareer(),
                 entity.getRecruitmentEndDate(),
-                filterValueInSummaryColumn("회사 명", entity.getSummaryData()),
+                getCompanyName(entity.getSummaryData()),
                 filterValueInSummaryColumn("직무 명", entity.getSummaryData()),
                 entity.getRecruitmentOriginalUrl(),
                 cleanRawDepthTwoString(entity.getDepthTwo()),
                 null
         );
+    }
+
+    private static String getCompanyName(String postSummary) {
+        String companyName = filterValueInSummaryColumn("회사 명", postSummary);
+        if(companyName == null) {
+            return filterValueInSummaryColumn("회사명", postSummary);
+        }
+        return companyName;
     }
 
     private static List<String> cleanRawDepthTwoString(String data) {
@@ -54,11 +62,19 @@ public record TodayApplyPostsResponseDto(
             return null;
         }
 
-        Pattern pattern = Pattern.compile("\\*\\*" + Pattern.quote(value) + "\\*\\*\\s*:\\s*(.*)");
-        Matcher matcher = pattern.matcher(summary);
+        String[] patterns = {
+                "\\*\\*\\s*" + Pattern.quote(value) + "\\s*\\*\\*\\s*:\\s*(.*)",
+                "\\*\\*\\s*" + Pattern.quote(value) + "\\s*:\\s*(.*)",
+                Pattern.quote(value) + "\\s*:\\s*(.*)"
+        };
 
-        if (matcher.find()) {
-            return matcher.group(1).trim();
+        for (String patternStr : patterns) {
+            Pattern pattern = Pattern.compile(patternStr, Pattern.CASE_INSENSITIVE);
+            Matcher matcher = pattern.matcher(summary);
+
+            if (matcher.find()) {
+                return matcher.group(1).trim();
+            }
         }
 
         return null;

--- a/src/main/java/com/project/zighang/domain/user/dto/response/TodayPostResponseDto.java
+++ b/src/main/java/com/project/zighang/domain/user/dto/response/TodayPostResponseDto.java
@@ -32,7 +32,7 @@ public record TodayPostResponseDto(
                 entity.getMinCareer(),
                 entity.getMaxCareer(),
                 entity.getRecruitmentEndDate(),
-                filterValueInSummaryColumn("회사 명", entity.getSummaryData()),
+                getCompanyName(entity.getSummaryData()),
                 filterValueInSummaryColumn("직무 명", entity.getSummaryData()),
                 entity.getRecruitmentOriginalUrl(),
                 cleanRawDepthTwoString(entity.getDepthTwo()),
@@ -40,7 +40,14 @@ public record TodayPostResponseDto(
         );
     }
 
-    // ✅ 기존 메소드 (기본값 false)
+    private static String getCompanyName(String postSummary) {
+        String companyName = filterValueInSummaryColumn("회사 명", postSummary);
+        if (companyName == null) {
+            return filterValueInSummaryColumn("회사명", postSummary);
+        }
+        return companyName;
+    }
+
     public static TodayPostResponseDto from(PostEntity entity) {
         return from(entity, false);
     }
@@ -59,11 +66,19 @@ public record TodayPostResponseDto(
             return null;
         }
 
-        Pattern pattern = Pattern.compile("\\*\\*" + Pattern.quote(value) + "\\*\\*\\s*:\\s*(.*)");
-        Matcher matcher = pattern.matcher(summary);
+        String[] patterns = {
+                "\\*\\*\\s*" + Pattern.quote(value) + "\\s*\\*\\*\\s*:\\s*(.*)",
+                "\\*\\*\\s*" + Pattern.quote(value) + "\\s*:\\s*(.*)",
+                Pattern.quote(value) + "\\s*:\\s*(.*)"
+        };
 
-        if (matcher.find()) {
-            return matcher.group(1).trim();
+        for (String patternStr : patterns) {
+            Pattern pattern = Pattern.compile(patternStr, Pattern.CASE_INSENSITIVE);
+            Matcher matcher = pattern.matcher(summary);
+
+            if (matcher.find()) {
+                return matcher.group(1).trim();
+            }
         }
 
         return null;


### PR DESCRIPTION
## 기능 설명
공고 조회 시 summary 데이터에서 회사 명을 필터링하는 과정에서 공고 summary 마다 회사 명을 표시하는 방식이 다양하여 필터링 되지 않는 부분이 있어 해결했습니다.
- [Fix: 공고 조회 데이터 회사 명 결측치 데이터 필터링 처리](https://github.com/X-Kusitms-1/ZIGHANG_ENTERPRISE_PROJECT_BE/commit/a1903a5520c84d1e7c6731d7808575fde923fe6c)

## 연결된 issue

close #96 

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 없음
- 버그 수정
  - 공고 요약에서 회사명 추출을 개선해 “회사 명”/“회사명” 표기, 굵게 표시, 공백 등 다양한 서식 변형을 안정적으로 처리합니다.
  - 대소문자·서식 차이로 회사명이 누락되던 문제를 줄여 목록 및 상세에 올바른 회사명이 더 자주 표시됩니다.
- 리팩터링
  - 회사명 추출 로직을 전담 헬퍼로 분리하고 요약 파싱을 다중 패턴 방식으로 정리해 유지보수성과 일관성을 향상했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->